### PR TITLE
Support for finding the latest Windows AMI from Amazon (defaults to 2…

### DIFF
--- a/lib/builderator/control/ami.rb
+++ b/lib/builderator/control/ami.rb
@@ -13,6 +13,7 @@ module Builderator
       module Owners
         SELF = 'self'.freeze
         UBUNTU = '099720109477'.freeze
+        AMAZON = 'amazon'.freeze
       end
 
       ## Filter fields defined in http://docs.aws.amazon.com/sdkforruby/api/Aws/EC2/Builderator::Util.ec2.html#describe_images-instance_method

--- a/lib/builderator/tasks/ami.rb
+++ b/lib/builderator/tasks/ami.rb
@@ -32,6 +32,16 @@ module Builderator
                                    'virtualization-type' => options['virtualization_type'],
                                    'architecture' => options['architecture'] }.merge(Hash[*args])).image_id
       end
+
+      desc 'windows SEARCH', 'Print the latest AMI ID for a Windows image matching the SEARCH string'
+      def windows(search = 'Windows_Server-2012-R2_RTM-English-64Bit-Base*')
+        puts Control::AMI.latest(:owner => Builderator::Control::AMI::Owners::AMAZON,
+                                 'root-device-type' => options['root_device_type'],
+                                 'virtualization-type' => options['virtualization_type'],
+                                 'architecture' => options['architecture'],
+                                 'name' => search).image_id
+      end
+
     end
   end
 end


### PR DESCRIPTION
…012 R2)

bfs-mbp-2450:builderator sirwin$ bundle exec build ami windows
ami-1df0ac78

From the AWS console:
AMI ID
ami-1df0ac78
AMI Name
Windows_Server-2012-R2_RTM-English-64Bit-Base-2015.10.26
