### PR TITLE
Fix Jetty generator defaults

### DIFF
--- a/lib/builderator/config/defaults.rb
+++ b/lib/builderator/config/defaults.rb
@@ -102,7 +102,7 @@ module Builderator
         jetty.packerfile :rm
         jetty.vagrantfile :rm
         jetty.thorfile :rm
-
+        jetty.readme :create
         jetty.cookbook :rm
       end
 

--- a/lib/builderator/config/file.rb
+++ b/lib/builderator/config/file.rb
@@ -238,6 +238,7 @@ module Builderator
           attribute :vagrantfile
           attribute :readme
           attribute :cookbook
+          attribute :rubocop
         end
 
         namespace :gemfile do

--- a/lib/builderator/config/file.rb
+++ b/lib/builderator/config/file.rb
@@ -236,6 +236,7 @@ module Builderator
           attribute :packerfile
           attribute :thorfile
           attribute :vagrantfile
+          attribute :readme
           attribute :cookbook
         end
 

--- a/lib/builderator/tasks/generator/base.rb
+++ b/lib/builderator/tasks/generator/base.rb
@@ -67,6 +67,7 @@ module Builderator
         end
 
         def rubocop
+          return if context.rubocop.nil?
           case context.rubocop.to_sym
           when :ignore then return
           when :rm


### PR DESCRIPTION
This sets a "readme" attribute for Jetty projects that's configured to skip the creation of a new README.md file if one already exists. It also fixes an issue where the "rubocop" parameter was being checked in Jetty projects. Running `build generate jetty` is working now.
