### PR TITLE
Debug builders

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,33 @@ The Packer integration generates Packer JSON and passes it to STDIN of `packer b
 Builderator can automatically detect versions from SCM tags, increment the latest version of an SCM branch by a variety of steps, and create new SCM tags for new versions.
 
 [Additional documentation](docs/versioning.md) describes CLI commands, configuration, and detailed behavior.
+
+## Generators
+
+Builderator includes tasks to generate common project configurations. The `Generator::Base` class is a Group of base steps to create/remove files common to many types of projects. `Generator::Jetty` extends `Base` to manage additional files specific to Jetty/JVM projects.
+
+Each type of project is configurable via collections in the `generator` namespace. Defaults are
+
+```ruby
+      generator.project :jetty do |jetty|
+        jetty.build_version '~> 1.0'
+        jetty.vagrant_install true
+        jetty.vagrant_version 'v1.7.4'
+
+        ## Task flags
+        jetty.berksfile :rm
+        jetty.buildfile :create
+        jetty.cookbook :rm
+        jetty.gemfile :create
+        jetty.gitignore :create
+        jetty.packerfile :rm
+        jetty.rubocop :create
+        jetty.readme :create
+        jetty.vagrantfile :rm
+        jetty.thorfile :rm
+      end
+```
+
+Valid actions for templates include `:ignore`, `:create` (update only if missing), `:sync` (create or update with prompt), and `:rm`. For some resources without templates, only the `:rm` action will have an effect.
+
+The `generator` subcommand includes `base` and `jetty` tasks.

--- a/builderator.gemspec
+++ b/builderator.gemspec
@@ -29,6 +29,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'chef', '~> 12.0'
   spec.add_dependency 'faraday_middleware', '~> 0.10.0'
   spec.add_dependency 'ignorefile'
-  spec.add_dependency 'mixlib-shellout', '~> 2.2'
   spec.add_dependency 'thor', '~> 0.19.0'
 end

--- a/lib/builderator/config/defaults.rb
+++ b/lib/builderator/config/defaults.rb
@@ -95,12 +95,10 @@ module Builderator
         vagrant.version 'v1.7.4'
       end
 
-      generator.project :jetty do |jetty|
-        jetty.build_version '~> 1.0'
-        jetty.vagrant_install true
-        jetty.vagrant_version 'v1.7.4'
+      generator.ruby.version '2.1.5'
+      generator.version '~> 1.0'
 
-        ## Task flags
+      generator.project :jetty do |jetty|
         jetty.berksfile :rm
         jetty.buildfile :create
         jetty.cookbook :rm
@@ -114,10 +112,6 @@ module Builderator
       end
 
       generator.project :legacy do |legacy|
-        legacy.build_version '~> 0.0'
-        legacy.vagrant_install true
-        legacy.vagrant_version 'v1.7.4'
-
         legacy.gemfile :sync
       end
 

--- a/lib/builderator/config/file.rb
+++ b/lib/builderator/config/file.rb
@@ -147,19 +147,42 @@ module Builderator
 
         ##
         # Packerfile
+        #
+        # This currently supports the AWS/EC2 builder.
         ##
         namespace :packer do
           collection :build do
             attribute :type
-            attribute :instance_type
-            attribute :source_ami
-            attribute :ssh_username
-            attribute :ami_virtualization_type
 
-            ## TODO: Share accounts
+            ## EC2 Placement and Virtualization parameters
+            attribute :region
+            attribute :availability_zone
+            attribute :vpc_id
+            attribute :subnet_id
+
+            attribute :instance_type
+            attribute :ami_virtualization_type
+            attribute :enhanced_networking
+            attribute :security_group_ids, :type => :list, :singular => :security_group_id
+            attribute :iam_instance_profile
+
+            attribute :source_ami
+            attribute :user_data
+            attribute :user_data_file
+
+            attribute :windows_password_timeout
+
+            ## Access parameters
+            attribute :ssh_username
+            attribute :ssh_keypair_name
+            attribute :ssh_private_key_file
+            attribute :ssh_private_ip
+            attribute :temporary_key_pair_name
 
             attribute :ami_name
             attribute :ami_description
+            attribute :ami_users, :type => :list
+            attribute :ami_regions, :type => :list
           end
         end
 
@@ -181,14 +204,26 @@ module Builderator
             attribute :box
             attribute :box_url
 
-            attribute :instance_type
-            attribute :source_ami
-            attribute :ssh_username
-            attribute :virtualization_type
-            attribute :instance_profile
+            attribute :region
+            attribute :availability_zone
             attribute :subnet_id
-            attribute :security_groups, :type => :list, :singular => :security_group
-            attribute :public_ip
+            attribute :private_ip_address
+
+            attribute :instance_type
+            attribute :security_groups, :type => :list
+            attribute :iam_instance_profile_arn
+
+            attribute :source_ami
+            attribute :user_data
+
+            attribute :ssh_username
+            attribute :keypair_name
+            attribute :private_key_path
+
+            attribute :associate_public_ip
+            attribute :ssh_host_attribute
+            attribute :instance_ready_timeout
+            attribute :instance_check_interval
           end
         end
       end
@@ -237,11 +272,11 @@ module Builderator
           attribute :gitignore
           attribute :packerfile
           attribute :rubocop
+          attribute :readme
           attribute :thorfile
           attribute :vagrantfile
           attribute :cookbook
         end
-
 
         namespace :ruby do
           attribute :version

--- a/lib/builderator/config/file.rb
+++ b/lib/builderator/config/file.rb
@@ -282,6 +282,8 @@ module Builderator
           attribute :version
         end
 
+        attribute :version
+
         namespace :gemfile do
           namespace :vagrant do
             attribute :install

--- a/lib/builderator/interface/packer.rb
+++ b/lib/builderator/interface/packer.rb
@@ -58,7 +58,8 @@ module Builderator
           :builders => builders,
           :provisioners => [{
             :type => 'shell',
-            :inline => "mkdir -p #{chef.staging_directory}/cache && chown ubuntu:ubuntu -R #{chef.staging_directory}"
+            :inline => "sudo mkdir -p #{chef.staging_directory}/cache && "\
+                       "sudo chown $(whoami) -R #{chef.staging_directory}"
           }]
         }
 

--- a/lib/builderator/interface/vagrant.rb
+++ b/lib/builderator/interface/vagrant.rb
@@ -60,17 +60,30 @@ module Builderator
         attribute :box_url
 
         attribute :region
-        attribute :instance_type
-        attribute :source_ami
-        attribute :ssh_username
-        attribute :virtualization_type
-        attribute :instance_profile
+        attribute :availability_zone
         attribute :subnet_id
-        attribute :security_groups, :type => :list, :singular => :security_group
-        attribute :public_ip
+        attribute :private_ip_address
+
+        attribute :instance_type
+        attribute :security_groups, :type => :list
+        attribute :iam_instance_profile_arn
+
+        attribute :source_ami
+        attribute :user_data
+
+        attribute :ssh_username
+        attribute :keypair_name
+        attribute :private_key_path
+
+        attribute :associate_public_ip
+        attribute :ssh_host_attribute
+        attribute :instance_ready_timeout
+        attribute :instance_check_interval
       end
 
       namespace :chef do
+        attribute :version, 'latest'
+
         attribute :cookbook_path
         attribute :data_bag_path
         attribute :environment_path

--- a/lib/builderator/tasks.rb
+++ b/lib/builderator/tasks.rb
@@ -65,6 +65,7 @@ module Builderator
       end
 
       desc 'image [PROFILE = default]', 'Build an AMI of PROFILE'
+      method_option :debug, :type => :boolean
       def image(profile = :default)
         prepare
         invoke Tasks::Packer, :build, [profile], options

--- a/lib/builderator/tasks/packer.rb
+++ b/lib/builderator/tasks/packer.rb
@@ -17,11 +17,12 @@ module Builderator
         true
       end
 
-      desc 'build ARGS', 'Run a build with the installed version of packer'
+      desc 'build [PROFILE=default *ARGS]', 'Run a build with the installed version of packer'
       def build(profile = :default, *args)
         @config ||= Interface.packer(profile)
 
-        run "packer build - #{ args.join('') }", :input => config.render
+        puts Interface.packer(profile).render if options['debug']
+        run_with_input "packer build - #{ args.join('') }", config.render
       end
     end
   end

--- a/lib/builderator/tasks/vagrant.rb
+++ b/lib/builderator/tasks/vagrant.rb
@@ -77,6 +77,33 @@ module Builderator
         end
       end
 
+      desc 'status [PROFILE [ARGS ...]]', 'Reprovision Vagrant VM(s)'
+      def status(profile = :default, *args)
+        @config ||= Interface.vagrant(profile)
+
+        inside config.directory do
+          command = 'ulimit -n 1024; '
+          command << 'VAGRANT_I_KNOW_WHAT_IM_DOING_PLEASE_BE_QUIET=true '
+          command << "#{@command} status #{args.join(' ')}"
+
+          run command
+        end
+      end
+
+      desc 'ssh [PROFILE [ARGS ...]]', 'SSH into Vagrant VM(s)'
+      def ssh(profile = :default, *args)
+        @config ||= Interface.vagrant(profile)
+
+        inside config.directory do
+          command = 'ulimit -n 1024; '
+          command << 'VAGRANT_I_KNOW_WHAT_IM_DOING_PLEASE_BE_QUIET=true '
+          command << "#{@command} ssh #{args.join(' ')}"
+
+          ## Connect to subprocesses STDIO
+          exec(command)
+        end
+      end
+
       desc 'destroy [PROFILE [ARGS ...]]', 'Destroy Vagrant VM(s)'
       method_option :force, :aliases => :f, :type => :boolean, :default => true
       def destroy(profile = :default, *args)

--- a/template/Gemfile.erb
+++ b/template/Gemfile.erb
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'builderator'
+gem 'builderator', '<%= generator.version %>'
 
 <% if generator.gemfile.vagrant.install -%>
 gem 'vagrant', :github => 'mitchellh/vagrant',

--- a/template/Vagrantfile.erb
+++ b/template/Vagrantfile.erb
@@ -15,20 +15,22 @@ Vagrant.configure('2') do |config|
 
   ## EC2 Provider
   config.vm.provider '<%= ec2.provider %>' do |ec2, override|
-    ec2.subnet_id = '<%= ec2.subnet_id %>'
-    ec2.security_groups = <%= ec2.security_groups %>
-    ec2.iam_instance_profile_arn = '<%= ec2.instance_profile %>'
-
-<% unless ec2.public_ip -%>
-    ## VPN Connected VPC
-    ec2.associate_public_ip = false
-    ec2.ssh_host_attribute = :private_ip_address
-<% end -%>
-    ec2.region = '<%= ec2.region %>'
-    ec2.instance_type = '<%= ec2.instance_type %>'
-
     override.vm.box = '<%= ec2.box %>'
     override.vm.box_url = '<%= ec2.box_url %>'
+    override.ssh.username = '<%= ec2.ssh_username %>'
+
+    ec2.region = '<%= ec2.region %>'
+    ec2.subnet_id = '<%= ec2.subnet_id %>'
+
+    ## VPN Connected VPC
+    ec2.associate_public_ip = <%= ec2.associate_public_ip %>
+    ec2.ssh_host_attribute = :<%= ec2.ssh_host_attribute %>
+
+    ec2.instance_type = '<%= ec2.instance_type %>'
+    ec2.security_groups = <%= ec2.security_groups %>
+    ec2.iam_instance_profile_arn = '<%= ec2.iam_instance_profile_arn %>'
+
+    ec2.ami = '<%= ec2.source_ami %>'
   end
 
   # config.vm.network :forwarded_port, :host => 9200, :guest => 9200
@@ -49,7 +51,7 @@ Vagrant.configure('2') do |config|
                       :destination => '<%= artifact.destination %>'
 <% end -%>
 
-  config.omnibus.chef_version = 'latest'
+  config.omnibus.chef_version = '<%= chef.version %>'
   config.vm.provision :chef_solo do |chef|
     chef.log_level = :<%= log_level %>
 

--- a/template/Vagrantfile.erb
+++ b/template/Vagrantfile.erb
@@ -20,17 +20,28 @@ Vagrant.configure('2') do |config|
     override.ssh.username = '<%= ec2.ssh_username %>'
 
     ec2.region = '<%= ec2.region %>'
+<% if ec2.has?(:subnet_id) -%>
     ec2.subnet_id = '<%= ec2.subnet_id %>'
+<% end -%>
 
     ## VPN Connected VPC
+<% if ec2.has?(:associate_public_ip) -%>
     ec2.associate_public_ip = <%= ec2.associate_public_ip %>
+<% end -%>
     ec2.ssh_host_attribute = :<%= ec2.ssh_host_attribute %>
 
+<% if ec2.has?(:instance_type) -%>
     ec2.instance_type = '<%= ec2.instance_type %>'
+<% end -%>
+<% if ec2.has?(:security_groups) -%>
     ec2.security_groups = <%= ec2.security_groups %>
+<% end -%>
+<% if ec2.has?(:iam_instance_profile_arn) -%>
     ec2.iam_instance_profile_arn = '<%= ec2.iam_instance_profile_arn %>'
-
+<% end -%>
+<% if ec2.has?(:source_ami) -%>
     ec2.ami = '<%= ec2.source_ami %>'
+<% end -%>
   end
 
   # config.vm.network :forwarded_port, :host => 9200, :guest => 9200
@@ -56,19 +67,19 @@ Vagrant.configure('2') do |config|
     chef.log_level = :<%= log_level %>
 
     chef.cookbooks_path = '<%= chef.cookbook_path %>'
-<% unless chef.data_bag_path.nil? -%>
+<% if chef.has?(:data_bag_path) -%>
     chef.data_bags_path = '<%= chef.data_bag_path %>'
 <% end -%>
-<% unless chef.environment_path.nil? -%>
+<% if chef.has?(:environment_path) -%>
     chef.environments_path = '<%= chef.environment_path %>'
 <% end -%>
     chef.provisioning_path = '<%= chef.staging_directory %>'
 
     chef.run_list = <%= chef.run_list %>
-<% unless chef.environment.nil? -%>
+<% if chef.has?(:environment) -%>
     chef.environment = '<%= chef.environment %>'
 <% end -%>
-<% unless chef.node_attrs.nil? -%>
+<% if chef.has?(:node_attrs) -%>
     chef.json = <%= chef.node_attrs %>
 <% end -%>
   end


### PR DESCRIPTION
- Fixes some mis-implementations in the EC2 providers for Packer and Vagrant.
- Adds `ssh` and `status` tasks to the vagrant wrapper
- Replaces `Mixlib::ShellOut` with `popen` to handle STDERR correctly
