### PR TITLE
1.0.x/interfaces

### DIFF
--- a/lib/builderator/config/attributes.rb
+++ b/lib/builderator/config/attributes.rb
@@ -37,7 +37,7 @@ module Builderator
           ## Setter
           define_method("#{attribute_name}=") do |arg|
             set_if_valid(attribute_name, arg, options)
-          end
+          end unless options[:type] == :list
         end
 
         ## Add a method the DSL

--- a/lib/builderator/config/defaults.rb
+++ b/lib/builderator/config/defaults.rb
@@ -19,7 +19,12 @@ module Builderator
       local do |local|
         local.vendor_path 'vendor'
         local.cookbook_path 'cookbooks'
-        local.staging_directory '/var/chef'
+      end
+
+      chef do |chef|
+        chef.log_level :info
+        chef.staging_directory '/var/chef'
+        chef.version = '12.5.1'
       end
 
       cookbook do |cookbook|
@@ -92,7 +97,7 @@ module Builderator
 
       generator.gemfile.vagrant do |vagrant|
         vagrant.install true
-        vagrant.version 'v1.7.4'
+        vagrant.version 'v1.8.0'
       end
 
       generator.ruby.version '2.1.5'

--- a/lib/builderator/config/file.rb
+++ b/lib/builderator/config/file.rb
@@ -87,8 +87,12 @@ module Builderator
 
         attribute :data_bag_path, :workspace => true
         attribute :environment_path, :workspace => true
+      end
 
+      namespace :chef do
+        attribute :log_level
         attribute :staging_directory
+        attribute :version
       end
 
       ##

--- a/lib/builderator/interface.rb
+++ b/lib/builderator/interface.rb
@@ -10,19 +10,12 @@ module Builderator
   ##
   # Base class for integration interfaces
   ##
-  class Interface < Config::Attributes
+  class Interface
     class << self
       def template(arg = nil)
         @template = arg unless arg.nil?
         @template
       end
-    end
-
-    def initialize(*_)
-      ## Ensure that Config is compiled before reading from it
-      Config.recompile
-
-      super
     end
 
     def directory
@@ -31,7 +24,11 @@ module Builderator
 
     def render
       ERB.new(Util.source_path(self.class.template).binread,
-              nil, '-', '@output_buffer').result(instance_eval('binding'))
+              nil, '-', '@output_buffer').result(Config.instance_eval('binding'))
+    end
+
+    def source
+      fail 'Interface does not provide a source!'
     end
 
     def write

--- a/lib/builderator/interface.rb
+++ b/lib/builderator/interface.rb
@@ -12,11 +12,34 @@ module Builderator
   ##
   class Interface
     class << self
+      def command(arg = nil)
+        @command = arg unless arg.nil?
+        @command
+      end
+
+      def from_gem(arg = nil)
+        @from_gem = arg unless arg.nil?
+        @from_gem || @command
+      end
+
       def template(arg = nil)
         @template = arg unless arg.nil?
         @template
       end
     end
+
+    ## Is vagrant in this bundle?
+    def bundled?
+      Gem.loaded_specs.key?(self.class.from_gem)
+    end
+
+    def which
+      return self.class.command if bundled?
+
+      ## Not in the bundle. Use system path
+      `which #{self.class.command}`.chomp.tap { |path| fail "Unable to locate a #{self.class.command} executable" if path.empty? }
+    end
+    alias_method :command, :which
 
     def directory
       Util.workspace

--- a/lib/builderator/interface/berkshelf.rb
+++ b/lib/builderator/interface/berkshelf.rb
@@ -1,8 +1,5 @@
-require_relative '../config'
 require_relative '../interface'
 require_relative '../util'
-
-require_relative '../control/cookbook'
 
 module Builderator
   # :nodoc:
@@ -17,6 +14,8 @@ module Builderator
     # Render an updated Berksfile
     ##
     class Berkshelf < Interface
+      from_gem 'berkshelf'
+      command 'berks'
       template 'template/Berksfile.erb'
 
       def vendor

--- a/lib/builderator/interface/berkshelf.rb
+++ b/lib/builderator/interface/berkshelf.rb
@@ -17,31 +17,18 @@ module Builderator
     # Render an updated Berksfile
     ##
     class Berkshelf < Interface
-      def initialize
-        super
-
-        includes Config.cookbook
-
-        vendor Config.local.cookbook_path
-        lockfile 'Berksfile.lock'
-      end
-
       template 'template/Berksfile.erb'
 
-      attribute :vendor
-      attribute :berkshelf_config
-      attribute :lockfile, :workspace => true
+      def vendor
+        Config.local.cookbook_path
+      end
 
-      attribute :sources, :type => :list
-      attribute :metadata
+      def lockfile
+        Util.workspace('Berksfile.lock')
+      end
 
-      collection :depends do
-        attribute :version
-        attribute :git
-        attribute :github
-        attribute :branch
-        attribute :tag
-        attribute :path
+      def berkshelf_config
+        Config.cookbook.berkshelf_config
       end
 
       def source

--- a/lib/builderator/interface/packer.rb
+++ b/lib/builderator/interface/packer.rb
@@ -1,6 +1,4 @@
-require_relative '../config'
 require_relative '../interface'
-require_relative '../util'
 
 module Builderator
   # :nodoc:
@@ -15,6 +13,7 @@ module Builderator
     # Generate packer.json
     ##
     class Packer < Interface
+      command 'packer'
       attr_reader :packerfile
 
       def initialize(*_)

--- a/lib/builderator/interface/vagrant.rb
+++ b/lib/builderator/interface/vagrant.rb
@@ -1,6 +1,4 @@
-require_relative '../config'
 require_relative '../interface'
-require_relative '../util'
 
 module Builderator
   # :nodoc:
@@ -15,7 +13,15 @@ module Builderator
     # Render a temporary Vagrantfile
     ##
     class Vagrant < Interface
+      command 'vagrant'
       template 'template/Vagrantfile.erb'
+
+      def command
+        c = ''
+        c << 'ulimit -n 1024; ' if bundled?
+        c << 'VAGRANT_I_KNOW_WHAT_IM_DOING_PLEASE_BE_QUIET=true ' if bundled?
+        c << which
+      end
 
       def source
         directory.join('Vagrantfile')

--- a/lib/builderator/interface/vagrant.rb
+++ b/lib/builderator/interface/vagrant.rb
@@ -6,9 +6,8 @@ module Builderator
   # :nodoc:
   class Interface
     class << self
-      def vagrant(profile = :default)
-        @vagrant ||= {}
-        @vagrant[profile] ||= Vagrant.new(profile)
+      def vagrant
+        @vagrant ||= Vagrant.new
       end
     end
 
@@ -16,83 +15,7 @@ module Builderator
     # Render a temporary Vagrantfile
     ##
     class Vagrant < Interface
-      def initialize(profile_ = :default)
-        super
-
-        includes Config.profile(profile_).vagrant
-        artifact.includes Config.profile(profile_).artifact
-
-        build_name Config.build_name
-        version Config.version
-        log_level Config.profile(profile_).log_level
-
-        ec2.region Config.aws.region
-
-        chef do |chef|
-          chef.includes Config.local
-          chef.includes Config.profile(profile_).chef
-        end
-      end
-
       template 'template/Vagrantfile.erb'
-
-      attribute :build_name
-      attribute :version
-      attribute :log_level
-
-      collection :artifact do
-        attribute :path
-        attribute :destination
-      end
-
-      namespace :local do
-        attribute :provider
-        attribute :box
-        attribute :box_url
-
-        attribute :cpus
-        attribute :memory
-      end
-
-      namespace :ec2 do
-        attribute :provider
-        attribute :box
-        attribute :box_url
-
-        attribute :region
-        attribute :availability_zone
-        attribute :subnet_id
-        attribute :private_ip_address
-
-        attribute :instance_type
-        attribute :security_groups, :type => :list
-        attribute :iam_instance_profile_arn
-
-        attribute :source_ami
-        attribute :user_data
-
-        attribute :ssh_username
-        attribute :keypair_name
-        attribute :private_key_path
-
-        attribute :associate_public_ip
-        attribute :ssh_host_attribute
-        attribute :instance_ready_timeout
-        attribute :instance_check_interval
-      end
-
-      namespace :chef do
-        attribute :version, 'latest'
-
-        attribute :cookbook_path
-        attribute :data_bag_path
-        attribute :environment_path
-        attribute :staging_directory
-
-        attribute :run_list, :type => :list, :singular => :run_list_item
-        attribute :environment
-        attribute :node_attrs
-      end
 
       def source
         directory.join('Vagrantfile')

--- a/lib/builderator/tasks/berkshelf.rb
+++ b/lib/builderator/tasks/berkshelf.rb
@@ -23,9 +23,10 @@ module Builderator
 
       desc 'vendor', 'Vendor a cookbook release and its dependencies'
       def vendor
+        invoke :configure, [], options
         empty_directory Interface.berkshelf.vendor
 
-        command = "berks vendor #{Interface.berkshelf.vendor} "
+        command = "#{Interface.berkshelf.command} vendor #{Interface.berkshelf.vendor} "
         command << "-c #{Interface.berkshelf.berkshelf_config} "
         command << "-b #{Interface.berkshelf.source}"
 
@@ -39,7 +40,7 @@ module Builderator
       def upload
         vendor
 
-        command = 'berks upload '
+        command = "#{Interface.berkshelf.command} upload "
         command << "-c #{Interface.berkshelf.berkshelf_config} "
         command << "-b #{Interface.berkshelf.source}"
 

--- a/lib/builderator/tasks/berkshelf.rb
+++ b/lib/builderator/tasks/berkshelf.rb
@@ -11,27 +11,26 @@ module Builderator
     class Berkshelf < Thor
       include Thor::Actions
 
-      attr_reader :config
-
-      def initialize(*_)
-        super
-        @config = Interface.berkshelf.write
-      end
 
       def self.exit_on_failure?
         true
       end
 
+      desc 'configure', 'Write a Berksfile into the project workspace'
+      def configure
+        Interface.berkshelf.write
+      end
+
       desc 'vendor', 'Vendor a cookbook release and its dependencies'
       def vendor
-        empty_directory config.vendor
+        empty_directory Interface.berkshelf.vendor
 
-        command = "berks vendor #{config.vendor} "
-        command << "-c #{config.berkshelf_config} "
-        command << "-b #{config.source}"
+        command = "berks vendor #{Interface.berkshelf.vendor} "
+        command << "-c #{Interface.berkshelf.berkshelf_config} "
+        command << "-b #{Interface.berkshelf.source}"
 
-        inside config.directory do
-          remove_file config.lockfile
+        inside Interface.berkshelf.directory do
+          remove_file Interface.berkshelf.lockfile
           run command
         end
       end
@@ -41,8 +40,8 @@ module Builderator
         vendor
 
         command = 'berks upload '
-        command << "-c #{config.berkshelf_config} "
-        command << "-b #{config.source}"
+        command << "-c #{Interface.berkshelf.berkshelf_config} "
+        command << "-b #{Interface.berkshelf.source}"
 
         run command
       end
@@ -55,8 +54,8 @@ module Builderator
       desc 'clean', 'Remove a local vendor directory'
       def clean
         remove_dir Interface.berkshelf.vendor
-        remove_file config.source
-        remove_file config.lockfile
+        remove_file Interface.berkshelf.source
+        remove_file Interface.berkshelf.lockfile
       end
     end
   end

--- a/lib/builderator/tasks/packer.rb
+++ b/lib/builderator/tasks/packer.rb
@@ -26,7 +26,7 @@ module Builderator
       desc 'build [PROFILE=default *ARGS]', 'Run a build with the installed version of packer'
       def build(profile = :default, *args)
         invoke :configure, [profile], options
-        run_with_input "packer build - #{ args.join('') }", Interface.packer.render
+        run_with_input "#{Interface.packer.command} build - #{ args.join('') }", Interface.packer.render
       end
     end
   end

--- a/lib/builderator/tasks/packer.rb
+++ b/lib/builderator/tasks/packer.rb
@@ -11,18 +11,22 @@ module Builderator
     class Packer < Thor
       include Thor::Actions
 
-      attr_reader :config, :command
-
       def self.exit_on_failure?
         true
       end
 
+      class_option :debug, :type => :boolean
+
+      desc 'configure [PROFILE=default]', 'Generate a packer configuration'
+      def configure(profile = :default)
+        Config.profile.use(profile)
+        puts Interface.packer.render if options['debug']
+      end
+
       desc 'build [PROFILE=default *ARGS]', 'Run a build with the installed version of packer'
       def build(profile = :default, *args)
-        @config ||= Interface.packer(profile)
-
-        puts Interface.packer(profile).render if options['debug']
-        run_with_input "packer build - #{ args.join('') }", config.render
+        invoke :configure, [profile], options
+        run_with_input "packer build - #{ args.join('') }", Interface.packer.render
       end
     end
   end

--- a/template/Berksfile.erb
+++ b/template/Berksfile.erb
@@ -1,10 +1,10 @@
 require 'builderator/patch/berkshelf'
 
-<% sources.each do |s| -%>
+<% cookbook.sources.each do |s| -%>
 source '<%= s %>'
 <% end -%>
-<% if metadata %>metadata<% end -%>
+<% if cookbook.metadata %>metadata<% end -%>
 
-<% depends.each do |name, cookbook| -%>
+<% cookbook.depends.each do |name, cookbook| -%>
 cookbook '<%= name %>', '<%= cookbook.fetch(:version, '>= 0.0.0') %>', <%= cookbook.to_hash %>
 <% end -%>

--- a/template/Vagrantfile.erb
+++ b/template/Vagrantfile.erb
@@ -5,42 +5,42 @@ Vagrant.configure('2') do |config|
   config.vm.hostname = 'builderator-<%= build_name %>'
 
   ## Local Provider
-  config.vm.provider '<%= local.provider %>' do |local, override|
-    local.memory = <%= local.memory %>
-    local.cpus = <%= local.cpus %>
+  config.vm.provider '<%= profile.current.vagrant.local.provider %>' do |local, override|
+    local.memory = <%= profile.current.vagrant.local.memory %>
+    local.cpus = <%= profile.current.vagrant.local.cpus %>
 
-    override.vm.box = '<%= local.box %>'
-    override.vm.box_url = '<%= local.box_url %>'
+    override.vm.box = '<%= profile.current.vagrant.local.box %>'
+    override.vm.box_url = '<%= profile.current.vagrant.local.box_url %>'
   end
 
   ## EC2 Provider
-  config.vm.provider '<%= ec2.provider %>' do |ec2, override|
-    override.vm.box = '<%= ec2.box %>'
-    override.vm.box_url = '<%= ec2.box_url %>'
-    override.ssh.username = '<%= ec2.ssh_username %>'
+  config.vm.provider '<%= profile.current.vagrant.ec2.provider %>' do |ec2, override|
+    override.vm.box = '<%= profile.current.vagrant.ec2.box %>'
+    override.vm.box_url = '<%= profile.current.vagrant.ec2.box_url %>'
+    override.ssh.username = '<%= profile.current.vagrant.ec2.ssh_username %>'
 
-    ec2.region = '<%= ec2.region %>'
-<% if ec2.has?(:subnet_id) -%>
-    ec2.subnet_id = '<%= ec2.subnet_id %>'
+    ec2.region = '<%= profile.current.vagrant.ec2.region %>'
+<% if profile.current.vagrant.ec2.has?(:subnet_id) -%>
+    ec2.subnet_id = '<%= profile.current.vagrant.ec2.subnet_id %>'
 <% end -%>
 
     ## VPN Connected VPC
-<% if ec2.has?(:associate_public_ip) -%>
-    ec2.associate_public_ip = <%= ec2.associate_public_ip %>
+<% if profile.current.vagrant.ec2.has?(:associate_public_ip) -%>
+    ec2.associate_public_ip = <%= profile.current.vagrant.ec2.associate_public_ip %>
 <% end -%>
-    ec2.ssh_host_attribute = :<%= ec2.ssh_host_attribute %>
+    ec2.ssh_host_attribute = :<%= profile.current.vagrant.ec2.ssh_host_attribute %>
 
-<% if ec2.has?(:instance_type) -%>
-    ec2.instance_type = '<%= ec2.instance_type %>'
+<% if profile.current.vagrant.ec2.has?(:instance_type) -%>
+    ec2.instance_type = '<%= profile.current.vagrant.ec2.instance_type %>'
 <% end -%>
-<% if ec2.has?(:security_groups) -%>
-    ec2.security_groups = <%= ec2.security_groups %>
+<% if profile.current.vagrant.ec2.has?(:security_groups) -%>
+    ec2.security_groups = <%= profile.current.vagrant.ec2.security_groups %>
 <% end -%>
-<% if ec2.has?(:iam_instance_profile_arn) -%>
-    ec2.iam_instance_profile_arn = '<%= ec2.iam_instance_profile_arn %>'
+<% if profile.current.vagrant.ec2.has?(:iam_instance_profile_arn) -%>
+    ec2.iam_instance_profile_arn = '<%= profile.current.vagrant.ec2.iam_instance_profile_arn %>'
 <% end -%>
-<% if ec2.has?(:source_ami) -%>
-    ec2.ami = '<%= ec2.source_ami %>'
+<% if profile.current.vagrant.ec2.has?(:source_ami) -%>
+    ec2.ami = '<%= profile.current.vagrant.ec2.source_ami %>'
 <% end -%>
   end
 
@@ -56,7 +56,7 @@ Vagrant.configure('2') do |config|
   ##
   # Sync build artifacts to the VM
   ##
-<% artifact.each do |name, artifact| -%>
+<% profile.current.artifact.each do |name, artifact| -%>
   config.vm.provision :file,
                       :source => '<%= artifact.path %>',
                       :destination => '<%= artifact.destination %>'
@@ -64,23 +64,23 @@ Vagrant.configure('2') do |config|
 
   config.omnibus.chef_version = '<%= chef.version %>'
   config.vm.provision :chef_solo do |chef|
-    chef.log_level = :<%= log_level %>
+    chef.log_level = :<%= chef.log_level %>
 
-    chef.cookbooks_path = '<%= chef.cookbook_path %>'
-<% if chef.has?(:data_bag_path) -%>
-    chef.data_bags_path = '<%= chef.data_bag_path %>'
+    chef.cookbooks_path = '<%= local.cookbook_path %>'
+<% if local.has?(:data_bag_path) -%>
+    chef.data_bags_path = '<%= local.data_bag_path %>'
 <% end -%>
-<% if chef.has?(:environment_path) -%>
-    chef.environments_path = '<%= chef.environment_path %>'
+<% if local.has?(:environment_path) -%>
+    chef.environments_path = '<%= local.environment_path %>'
 <% end -%>
     chef.provisioning_path = '<%= chef.staging_directory %>'
 
-    chef.run_list = <%= chef.run_list %>
-<% if chef.has?(:environment) -%>
-    chef.environment = '<%= chef.environment %>'
+    chef.run_list = <%= profile.current.chef.run_list %>
+<% if profile.current.chef.has?(:environment) -%>
+    chef.environment = '<%= profile.current.chef.environment %>'
 <% end -%>
-<% if chef.has?(:node_attrs) -%>
-    chef.json = <%= chef.node_attrs %>
+<% if profile.current.chef.has?(:node_attrs) -%>
+    chef.json = <%= profile.current.chef.node_attrs %>
 <% end -%>
   end
 end


### PR DESCRIPTION
This PR introduces `use(:name)` and `current` methods into the Collection DSL. This allows a task to pin one element in a collection as active with the `use` setter, and for consumers, like templates, to consume that pinned element via the `current` getter.

With this feature, the CLI wrapper interfaces can be hugely simplified, and all templates can be refactored to use the Config namespace consistently.

The Interface class has also been expanded to check if a run-time dependency is included in the bundle, or exists elsewhere on the system. If the dependency, like Vagrant, is not bundled, the Interface will use `which` to resolve it's absolute path on the system to ensure it isn't shadowed by an incorrect bin-stub in your ruby environment.
