### PR TITLE
1.0.x/policies

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,6 +39,15 @@ In the example above, the same collection is accessed twice. The final result lo
 }
 ```
 
+## Helper Methods
+
+* `lookup(source, query)` - Query an external data-source for a value inline.
+* Source `:image`: Return an array of EC2 instances, sorted by `creation_date` (See http://docs.aws.amazon.com/sdkforruby/api/Aws/EC2/Client.html#describe_images-instance_method)
+
+* `vendored(name, path)` - Return the absolute path to `path` in the named vendor resource. _ Hint: Use this helper to reference Builderator policy files and Chef data_bag and environment sources in an external repository._
+
+## Configuration File DSL
+
 Collections and namespaces may be nested indefinitely.
 
 * [Namespace `cookbook`](configuration/cookbook.md)
@@ -51,23 +60,38 @@ Collections and namespaces may be nested indefinitely.
 * `version` The version of this release of the build. Auto-populated by `autoversion` by default
 * `cleanup` Enable post-build cleanup tasks. Default `true`
 
+* `relative(path)` - Return the absolute path to `path` relative to the calling Buildfile _Hint: Use this helper to reference templates included with a vendored policy._
+
 ## Namespace `autoversion`
 
 * `create_tags` During a release, automatically create and push new SCM tags
 * `search_tags` Use SCM tags to determine the current version of the build
 
+## Namespace `chef`
+
+Global configurations for chef provisioners in Vagrant and Packer
+
+* `log_level` Chef client/solo log level
+* `staging_directory` the path in VMs and images that Chef artifacts should be mounted/copied to. Defaults to `/var/chef`
+* `version` The version of chef to install with Omnibus
+
 ## Namespace `local`
 
 Local paths used for build tasks
 
-* `vendor_path` The workspace-rooted path at which to store vendored artifacts. Default `.builderator/vendor`
-* `cookbook_path` The workspace-rooted path at which to vendor cookbooks. Default `.builderator/cookbooks`
-* `data_bag_path` and `environment_path` Workspace-rooted paths that Chef providers should load data-bag and environment documents from. Defaults to `.builderator/vendor/chef`. This assumes that you provide a `chef` vendor that fetches a valid Chef-Repo with valid `data_bags` and `environments` directories.
-* `staging_directory` the path in VMs and images that Chef artifacts should be mounted/copied to. Defaults to `/var/chef`
+* `cookbook_path` Path at which to vendor cookbooks. Default `.builderator/cookbooks`
+* `data_bag_path` and `environment_path` Paths that Chef providers should load data-bag and environment documents from.
+
+## Collection `policy`
+
+Load additional attributes into the parent file from a relative path
+
+* `path` Load a DSL file, relative => true
+* `json` Load a JSON file relative => true
 
 ## Namespace `aws`
 
-AWS API configurations. _Hint: Configure these in `$HOME/.builderator/Buildfile`!_
+AWS API configurations. _Hint: Configure these in `$HOME/.builderator/Buildfile`, or use a built-in credential source, e.g. ~/.aws/config!_
 
 * `region` The default AWS region to use
 * `access_key` and `secret_key` A valid IAM key-pair
@@ -76,12 +100,15 @@ AWS API configurations. _Hint: Configure these in `$HOME/.builderator/Buildfile`
 
 Fetch remote artifacts for builds
 
-* `path` link to a local file/directory
-* `git`, `GitHub` Fetch a git repository
-* `branch`
-* `tag`
-* `ref`
-* `rel` Checkout a sub-directory of
+* Sources:
+  * `path` Link to a local file/directory
+  * `git` Fetch a git repository
+  * `github` Fetch a git repository from a GitHub URI (e.g. `OWNER/REPO`) using the SSH protocol. You must have a valid SSH key configuration for public GitHub.
+* Git-specific parameters:
+  * `branch`
+  * `tag`
+  * `ref`
+  * `rel` Checkout a sub-directory of a git repository
 
 ## Namespace `cleaner`
 
@@ -95,3 +122,33 @@ Maximum number of resources to remove without manual override
 * `launch_configs`
 * `snapshots`
 * `volumes`
+
+## Namespace `generator`
+
+Configurations for the `generator` task
+
+### Collection `project`
+
+* `builderator.version` The version of Builderator to install with Bundler
+* `ruby.version` The version of ruby to require for Bundler and `rbenv`/`rvm`
+
+#### Namespace `vagrant`
+
+* `install` Boolean, include the vagrant gem from GitHub `mitchellh/vagrant`
+* `version` The version of Vagrant to use from GitHub, if `install` is true
+
+##### Collection `plugin`
+
+Vagrant plugins to install, either with the `build vagrant plugin` command, for a system-wide installation of Vagrant, or in the generated Gemfile if `install` is true
+
+#### Collection `resource`
+
+Add a managed file to the project definition
+
+* `action` One of
+  * `:create` Add a file from a template if it's missing
+  * `:sync` Create or update a file from a template, stopping to ask for instructions if the file exists and the templated output does not match
+  * `:ignore` Do nothing
+  * `:rm` Delete a file if it exists
+* `path` One or more path in the working directory the this resource manages. Action `:rm` will delete multiple files, while `:create` and `:sync` will only use the first element of the list as their destination.
+* `template` The path to an ERB template. Must be an absolute path: use the [helpers](#helpers) in the Buildfile namespace to extend paths inline.

--- a/lib/builderator/config/attributes.rb
+++ b/lib/builderator/config/attributes.rb
@@ -237,12 +237,6 @@ module Builderator
           @block.call(self) if @block
           self
         end
-
-        ## Copy attributes from another instance in the same collection
-        def extends(instance_name)
-          return unless collection.is_a?(Collection)
-          merge(collection[instance_name])
-        end
       end
 
       ##

--- a/lib/builderator/config/defaults.rb
+++ b/lib/builderator/config/defaults.rb
@@ -1,4 +1,5 @@
 require_relative './file'
+require_relative '../util'
 
 module Builderator
   # :nodoc
@@ -15,13 +16,12 @@ module Builderator
       vendor() {}
 
       autoversion do |autoversion|
-        autoversion.create_tags true
+        autoversion.create_tags false
         autoversion.search_tags true
       end
 
       local do |local|
-        local.vendor_path 'vendor'
-        local.cookbook_path 'cookbooks'
+        local.cookbook_path Util.workspace('cookbooks')
       end
 
       chef do |chef|
@@ -79,8 +79,6 @@ module Builderator
             build.ami_description Config.description
           end
         end
-
-        profile(:bake).extends :default
       end
 
       cleaner do |cleaner|
@@ -98,10 +96,10 @@ module Builderator
         end
       end
 
-      generator.project :default do |base|
-        base.builderator.version '~> 1.0'
+      generator.project :default do |default|
+        default.builderator.version '~> 1.0'
 
-        base.vagrant do |vagrant|
+        default.vagrant do |vagrant|
           vagrant.install false
           vagrant.version 'v1.8.0'
 
@@ -109,63 +107,61 @@ module Builderator
           vagrant.plugin 'vagrant-omnibus'
         end
 
-        base.resource :berksfile do |berksfile|
+        default.resource :berksfile do |berksfile|
           berksfile.path 'Berksfile', 'Berksfile.lock'
           berksfile.action :rm
         end
 
-        base.resource :buildfile do |buildfile|
+        default.resource :buildfile do |buildfile|
           buildfile.path 'Buildfile'
           buildfile.action :create
-          buildfile.embedded 'template/Buildfile.erb'
+          buildfile.template 'template/Buildfile.erb'
         end
 
-        base.resource :cookbook do |cookbook|
+        default.resource :cookbook do |cookbook|
           cookbook.path 'cookbook'
           cookbook.action :rm
         end
 
-        base.resource :gemfile do |gemfile|
+        default.resource :gemfile do |gemfile|
           gemfile.path 'Gemfile'
           gemfile.action :create
-          gemfile.embedded 'template/Gemfile.erb'
+          gemfile.template 'template/Gemfile.erb'
         end
 
-        base.resource :gitignore do |gitignore|
+        default.resource :gitignore do |gitignore|
           gitignore.path '.gitignore'
           gitignore.action :create
-          gitignore.embedded 'template/gitignore.erb'
+          gitignore.template 'template/gitignore.erb'
         end
 
-        base.resource :packerfile do |packerfile|
+        default.resource :packerfile do |packerfile|
           packerfile.path 'packer.json', 'packer'
           packerfile.action :rm
         end
 
-        base.resource :rubocop do |rubocop|
+        default.resource :rubocop do |rubocop|
           rubocop.path '.rubocop.yml'
           rubocop.action :create
-          rubocop.embedded 'template/rubocop.erb'
+          rubocop.template 'template/rubocop.erb'
         end
 
-        base.resource :readme do |readme|
+        default.resource :readme do |readme|
           readme.path 'README.md'
           readme.action :create
-          readme.embedded 'template/README.md.erb'
+          readme.template 'template/README.md.erb'
         end
 
-        base.resource :thorfile do |thorfile|
+        default.resource :thorfile do |thorfile|
           thorfile.path 'Thorfile'
           thorfile.action :rm
         end
 
-        base.resource :vagrantfile do |vagrantfile|
+        default.resource :vagrantfile do |vagrantfile|
           vagrantfile.path 'Vagrantfile'
           vagrantfile.action :rm
         end
       end
-
-      generator.project(:jetty).extends(:default)
     end
   end
 end

--- a/lib/builderator/config/defaults.rb
+++ b/lib/builderator/config/defaults.rb
@@ -54,9 +54,8 @@ module Builderator
           vagrant.local do |local|
             local.provider :virtualbox
 
-            local.box 'ubuntu-14.04-x86_64'
-            local.box_url 'https://cloud-images.ubuntu.com/vagrant/trusty/'\
-                          'current/trusty-server-cloudimg-amd64-vagrant-disk1.box'
+            ## Atlas metadata for Ubuntu cloud-images: https://atlas.hashicorp.com/ubuntu/boxes/trusty64
+            local.box 'ubuntu/trusty64'
 
             local.memory 1024
             local.cpus 2

--- a/lib/builderator/config/defaults.rb
+++ b/lib/builderator/config/defaults.rb
@@ -12,9 +12,6 @@ module Builderator
       version '0.0.0'
       build_number 0
 
-      ## Ensure that attributes[:vendor] is a populated
-      vendor() {}
-
       autoversion do |autoversion|
         autoversion.create_tags false
         autoversion.search_tags true

--- a/lib/builderator/tasks/vendor.rb
+++ b/lib/builderator/tasks/vendor.rb
@@ -29,7 +29,7 @@ module Builderator
         remove_dir Util.vendor(name)
       end
 
-      desc 'fatch NAME', 'Fetch vendor NAME from its source'
+      desc 'fetch NAME', 'Fetch vendor NAME from its source'
       def fetch(name = :default)
         empty_directory Util::VENDOR
 

--- a/lib/builderator/tasks/vendor.rb
+++ b/lib/builderator/tasks/vendor.rb
@@ -26,14 +26,14 @@ module Builderator
         ## Clean up all vendors
         return Config.vendor.each { |n, _| clean(n) } if name.nil?
 
-        remove_dir ::File.join(Config.local.vendor_path, name.to_s)
+        remove_dir Util.vendor(name)
       end
 
       desc 'fatch NAME', 'Fetch vendor NAME from its source'
       def fetch(name = :default)
-        empty_directory Config.local.vendor_path
+        empty_directory Util::VENDOR
 
-        path = Pathname.new(Config.local.vendor_path).join(name.to_s)
+        path = Util.vendor(name)
         params = Config.vendor(name)
 
         if params.has?(:github)
@@ -46,6 +46,9 @@ module Builderator
           say_status :vendor, "#{ name } from path #{ params.path }"
           _fetch_path(path, params)
         end
+
+        ## Include any policies embedded in this vendor
+        Config.recompile
       end
 
       no_commands do
@@ -82,8 +85,8 @@ module Builderator
         end
 
         def _fetch_path(path, params)
-          return if path.exist?
-          create_link path.to_s, Util.relative_path(params[:path])
+          remove_dir path.to_s if path.exist?
+          create_link path.to_s, params.path.to_s
         end
       end
     end

--- a/lib/builderator/util.rb
+++ b/lib/builderator/util.rb
@@ -7,6 +7,7 @@ module Builderator
   module Util
     GEM_PATH = Pathname.new(__FILE__).join('../../..').expand_path
     WORKSPACE = '.builderator'.freeze
+    VENDOR = 'vendor'.freeze
 
     class << self
       ##
@@ -24,15 +25,19 @@ module Builderator
       # Relative path from working directory
       ##
       def relative_path(*relative)
-        Pathname.pwd.join(*relative).expand_path
+        Pathname.pwd.join(*(relative.flatten.map(&:to_s))).expand_path
       end
 
       def workspace(*relative)
-        relative_path.join(WORKSPACE).join(*relative)
+        relative_path(WORKSPACE, relative)
+      end
+
+      def vendor(*relative)
+        workspace(VENDOR, relative)
       end
 
       def source_path(*relative)
-        GEM_PATH.join(*relative).expand_path
+        GEM_PATH.join(*(relative.flatten.map(&:to_s))).expand_path
       end
 
       ##


### PR DESCRIPTION
This PR adds facilities to the Config::File DSL to load additional partial files from local paths. This allows us to define a policy-level configurations in an external git repo, vendor the repo, and reference those configurations in one of the main configuration sources using the `vendored(name, path)` helper
