### PR TITLE
Fixes #33: The configuration compiler did not detect changes correctly

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,6 +39,20 @@ In the example above, the same collection is accessed twice. The final result lo
 }
 ```
 
+## Extending collection items
+
+_**BETA** This feature may result in un-compilable configurations when list-type attributes need to be overridden. We need to improve the interface for setting vs. appending to a list._
+
+A collection item can extend another item using a hash-notation:
+
+```ruby
+profile :bake => Config.profile(:default) do |bake|
+  ...
+end
+```
+
+The `bake` profile will now be pre-populated with all of the values in the `default` profile, which can be overridden.
+
 ## Helper Methods
 
 * `lookup(source, query)` - Query an external data-source for a value inline.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,9 +1,9 @@
 Configuration DSL
 =================
 
-The configuration DSL is made up of key-value pairs, called `attributes`, which are grouped into `namespaces` and `collections`.
+Builderator's configuration language is a Ruby DSL, composed of `attributes`,  which are grouped into `namespaces`. A `namespace` may be singular, or it may be part of a `collection`, in which case more than one named entry may be defined with the same `namespace`.
 
-Namespaces can accessed with blocks, or with a fluent interface:
+Namespaces and collections can accessed with blocks, or with a fluent interface:
 
 ```ruby
 aws do |a|
@@ -14,44 +14,123 @@ end
 aws.region = 'us-west-1'
 ```
 
-Collections are named sets. Like namespaces, they can be accessed with blocks, or a fluent interface:
+Collections are sets of named items. Like namespaces, they can be accessed with blocks, or a fluent interface:
 
 ```ruby
 profile :default do |default_profile|
-  default_profile.chef.run_list 'apt:default', 'redis:server'
+  default_profile.chef.run_list 'apt:default', 'redis:server', 'app::server'
 end
 
 profile(:default).chef.environment 'development'
+profile(:prod).chef.environment 'production'
 ```
 
-In the example above, the same collection is accessed twice. The final result looks like:
+In the example above, the same collection item is accessed twice. A second item is also defined in the same collection. The final result looks like:
 
 ```json
 {
   "profile": {
     "default": {
       "chef": {
-        "run_list": ["apt:default", "redis:server"],
+        "run_list": ["apt:default", "redis:server", "app::server"],
         "environment": "development"
+      }
+    },
+    "prod": {
+      "chef": {
+        "environment": "production"
       }
     }
   }
 }
 ```
 
-## Extending collection items
+Collections and namespaces may be nested indefinitely.
 
-_**BETA** This feature may result in un-compilable configurations when list-type attributes need to be overridden. We need to improve the interface for setting vs. appending to a list._
+## Extending Collection Items
 
 A collection item can extend another item using a hash-notation:
 
 ```ruby
-profile :bake => Config.profile(:default) do |bake|
-  ...
+profile :prod => Config.profile(:default) do |prod|
+  prod.chef.environment = 'production'
 end
 ```
 
-The `bake` profile will now be pre-populated with all of the values in the `default` profile, which can be overridden.
+Following the example, above, the `prod` profile will now be pre-populated with all of the values in the `default` profile, which can be overridden:
+
+```json
+{
+  "profile": {
+    "default": {
+      "chef": {
+        "run_list": ["apt:default", "redis:server", "app::server"],
+        "environment": "development"
+      }
+    },
+    "prod": {
+      "chef": {
+        "run_list": ["apt:default", "redis:server", "app::server"],
+        "environment": "production"
+      }
+    }
+  }
+}
+```
+
+## List-type Attributes
+
+Some configuration attributes are actually ordered sets of values. These are referred to as `list-type` attributes, and have some additional options:
+
+```ruby
+chef.run_list 'apt:default', :mode => :override
+```
+
+The `:mode` parameter tells the configuration manager how how to compile a list-type attribute that is defined in two or more layers, or is modified in an extended collection item. Currently, two modes are implemented:
+
+* `:override` - Instructs the compiler to discard any elements that have been loaded from lower layers. This does not have any effect upon the behavior of the same attribute in higher layers, meaning that the current layer's override may be appended to or overridden by future layers, according to their `mode` parameter.
+* `:union` - Default behavior. Instructs the compiler to perform a set-union between the current layer's elements and the current set of elements compiled from lower layers.
+
+List-type attributes may also have an `appender method`, which allows elements to be appended to the current set _in that layer_. **List-type attributes do not have an `=` setter.**
+
+Because `chef.run_list` is a list-type attribute, we can tell Builderator to override the `default` profile's `run_list`:
+
+```ruby
+profile :prod => Config.profile(:default) do |prod|
+  prod.chef.environment = 'production'
+  prod.chef.run_list 'apt:default', 'redis:server', 'app::server', 'app::tls', :mode => :override
+end
+```
+
+We could also append to `default`'s `run_list` without modifying `default`:
+
+```ruby
+profile :prod => Config.profile(:default) do |prod|
+  prod.chef.environment = 'production'
+  prod.chef.run_list_item 'app::tls'
+end
+```
+
+Both of the above will result in the same compiled configuration:
+
+```json
+{
+  "profile": {
+    "default": {
+      "chef": {
+        "run_list": ["apt:default", "redis:server", "app::server"],
+        "environment": "development"
+      }
+    },
+    "prod": {
+      "chef": {
+        "run_list": ["apt:default", "redis:server", "app::server", "app::tls"],
+        "environment": "production"
+      }
+    }
+  }
+}
+```
 
 ## Helper Methods
 
@@ -60,9 +139,9 @@ The `bake` profile will now be pre-populated with all of the values in the `defa
 
 * `vendored(name, path)` - Return the absolute path to `path` in the named vendor resource. _ Hint: Use this helper to reference Builderator policy files and Chef data_bag and environment sources in an external repository._
 
-## Configuration File DSL
+* `relative(path)` - Return the absolute path to `path` relative to the calling Buildfile _Hint: Use this helper to reference templates included with a vendored policy._
 
-Collections and namespaces may be nested indefinitely.
+## Configuration Parameters
 
 * [Namespace `cookbook`](configuration/cookbook.md)
 * [Collection `profile`](configuration/profile.md)
@@ -74,14 +153,12 @@ Collections and namespaces may be nested indefinitely.
 * `version` The version of this release of the build. Auto-populated by `autoversion` by default
 * `cleanup` Enable post-build cleanup tasks. Default `true`
 
-* `relative(path)` - Return the absolute path to `path` relative to the calling Buildfile _Hint: Use this helper to reference templates included with a vendored policy._
-
-## Namespace `autoversion`
+### Namespace `autoversion`
 
 * `create_tags` During a release, automatically create and push new SCM tags
 * `search_tags` Use SCM tags to determine the current version of the build
 
-## Namespace `chef`
+### Namespace `chef`
 
 Global configurations for chef provisioners in Vagrant and Packer
 
@@ -89,28 +166,28 @@ Global configurations for chef provisioners in Vagrant and Packer
 * `staging_directory` the path in VMs and images that Chef artifacts should be mounted/copied to. Defaults to `/var/chef`
 * `version` The version of chef to install with Omnibus
 
-## Namespace `local`
+### Namespace `local`
 
 Local paths used for build tasks
 
 * `cookbook_path` Path at which to vendor cookbooks. Default `.builderator/cookbooks`
 * `data_bag_path` and `environment_path` Paths that Chef providers should load data-bag and environment documents from.
 
-## Collection `policy`
+### Collection `policy`
 
 Load additional attributes into the parent file from a relative path
 
 * `path` Load a DSL file, relative => true
 * `json` Load a JSON file relative => true
 
-## Namespace `aws`
+### Namespace `aws`
 
 AWS API configurations. _Hint: Configure these in `$HOME/.builderator/Buildfile`, or use a built-in credential source, e.g. ~/.aws/config!_
 
 * `region` The default AWS region to use
 * `access_key` and `secret_key` A valid IAM key-pair
 
-## Collection `vendor`
+### Collection `vendor`
 
 Fetch remote artifacts for builds
 
@@ -124,11 +201,11 @@ Fetch remote artifacts for builds
   * `tag` or `ref` - A SHA-ish or SCM tag to check out. Overrides `branch`.
   * `rel` Checkout a sub-directory of a git repository
 
-## Namespace `cleaner`
+### Namespace `cleaner`
 
 Configuration parameters for `build-clean` tasks
 
-### Namespace `limits`
+#### Namespace `limits`
 
 Maximum number of resources to remove without manual override
 
@@ -137,25 +214,25 @@ Maximum number of resources to remove without manual override
 * `snapshots`
 * `volumes`
 
-## Namespace `generator`
+### Namespace `generator`
 
 Configurations for the `generator` task
 
-### Collection `project`
+#### Collection `project`
 
 * `builderator.version` The version of Builderator to install with Bundler
 * `ruby.version` The version of ruby to require for Bundler and `rbenv`/`rvm`
 
-#### Namespace `vagrant`
+##### Namespace `vagrant`
 
 * `install` Boolean, include the vagrant gem from GitHub `mitchellh/vagrant`
 * `version` The version of Vagrant to use from GitHub, if `install` is true
 
-##### Collection `plugin`
+###### Collection `plugin`
 
 Vagrant plugins to install, either with the `build vagrant plugin` command, for a system-wide installation of Vagrant, or in the generated Gemfile if `install` is true
 
-#### Collection `resource`
+##### Collection `resource`
 
 Add a managed file to the project definition
 

--- a/lib/builderator/config/attributes.rb
+++ b/lib/builderator/config/attributes.rb
@@ -69,8 +69,6 @@ module Builderator
               @attributes[namespace_name],
               :name => namespace_name,
               :parent => self, &block)
-
-            nodes[namespace_name]
           end
         end
 

--- a/lib/builderator/config/attributes.rb
+++ b/lib/builderator/config/attributes.rb
@@ -2,6 +2,7 @@ require 'forwardable'
 require 'json'
 
 require_relative './rash'
+require_relative './list'
 
 module Builderator
   module Config
@@ -18,31 +19,30 @@ module Builderator
           # Helpers for Array-type attributes
           ##
           if options[:type] == :list
-            default = Array
+            define_method(attribute_name) do |*arg, **run_options|
+              ## Instantiate List if it doesn't exist yet. `||=` will always return a new Rash.
+              @attributes[attribute_name] = Config::List.new(run_options) unless @attributes.has?(attribute_name, Config::List)
 
-            ## Add an appender DSL method
-            define_method(options[:singular]) do |*args|
-              append_if_valid(attribute_name, args.flatten, default, options)
+              @attributes[attribute_name].set(*arg.flatten) unless arg.empty?
+              @attributes[attribute_name]
+            end
+
+            define_method(options[:singular]) do |*arg, **run_options|
+              send(attribute_name, run_options).push(*arg.flatten)
             end if options.include?(:singular)
+
+            return
           end
 
           ## Getter/Setter
           define_method(attribute_name) do |*arg|
-            arg.flatten!
-            arg = arg.first unless options[:type] == :list
-
-            set_or_return(attribute_name, arg, default, options)
+            set_or_return(attribute_name, arg.first, default, options)
           end
 
           ## Setter
           define_method("#{attribute_name}=") do |arg|
             set_if_valid(attribute_name, arg, options)
-          end unless options[:type] == :list
-        end
-
-        ## Add a method the DSL
-        def define(method_name, &block)
-          define_method(method_name, &block)
+          end
         end
 
         ##
@@ -58,7 +58,7 @@ module Builderator
         # end
         # ```
         #
-        # Multiple calls to the DSL method will are safe and will
+        # Multiple calls to the DSL method are safe and will
         # update the same sub-node.
         ##
         def namespace(namespace_name, &definition)
@@ -207,20 +207,8 @@ module Builderator
         @attributes[key] = arg
       end
 
-      def append_if_valid(key, arg, default = Array, **options)
-        ## TODO: define validation interface
-
-        attribute = set_or_return(key, nil, default, options)
-        arg.reject! { |item| attribute.include?(item) }
-
-        return if arg.empty?
-
-        dirty(true) ## A mutation has occured
-        attribute.push(*arg)
-      end
-
       def set_or_return(key, arg = nil, default = nil, **options)
-        if arg.nil? || (arg.is_a?(Array) && arg.empty?)
+        if arg.nil?
           return @attributes[key] if @attributes.has?(key)
 
           ## Default

--- a/lib/builderator/config/file.rb
+++ b/lib/builderator/config/file.rb
@@ -181,7 +181,7 @@ module Builderator
         # Chef configurations
         ##
         namespace :chef do
-          attribute :run_list
+          attribute :run_list, :type => :list, :singular => :run_list_item
           attribute :environment
           attribute :node_attrs
         end

--- a/lib/builderator/config/list.rb
+++ b/lib/builderator/config/list.rb
@@ -1,0 +1,63 @@
+module Builderator
+  module Config
+    ##
+    # Extend Array with context about how its values should be merged with other
+    # configuration layers. Possible modes are:
+    #
+    # * 'override' - Do not merge. Replace the other node's elements
+    # * 'union' - Perform a set-union on the elements of this and the other node
+    ##
+    class List < Array
+      class << self
+        def coerce(somehting, options = {})
+          return somehting if somehting.is_a?(self)
+          return new(options).push(*somehting) if somehting.is_a?(Array)
+
+          ## `somehting` is not a valid input. Just give back an instance.
+          new([], options)
+        end
+      end
+
+      attr_reader :mode
+
+      def initialize(from = nil, **options)
+        @mode = options.fetch(:mode, :union)
+
+        merge!(from) unless from.nil?
+      end
+
+      def clone
+        self.class.new(self, :mode => mode)
+      end
+
+      def set(*elements)
+        clear
+        push(*elements)
+      end
+
+      ##
+      # Combine elements with `other` according to `other`'s `mode`
+      ##
+      def merge!(other)
+        other = self.class.coerce(other)
+
+        case other.mode
+        when :override
+          return false if self == other
+          set(*other)
+
+        when :union
+          merged = self | other
+          return false if merged == self
+
+          set(*merged)
+
+        else
+          fail "Invalid List mode #{other.mode}!"
+        end
+
+        true
+      end
+    end
+  end
+end

--- a/lib/builderator/config/rash.rb
+++ b/lib/builderator/config/rash.rb
@@ -1,3 +1,5 @@
+require_relative './list'
+
 module Builderator
   module Config
     ##
@@ -39,7 +41,9 @@ module Builderator
         seal(false)
       end
 
-      alias_method :has?, :include?
+      def has?(key, klass = BasicObject)
+        include?(key) && fetch(key).is_a?(klass)
+      end
 
       ## Symbolize keys
       [:include?, :[], :fetch, :[]=, :store].each do |m|
@@ -60,11 +64,10 @@ module Builderator
           next if self[k] == v
 
           ## Merge Arrays
-          if fetch(k, nil).is_a?(Array) && v.is_a?(Array)
-            next if (self[k] | v) == self[k]
-
-            dirty = true
-            next self[k] |= v
+          if v.is_a?(Array)
+            self[k] = has?(k) ? Config::List.coerce(self[k]) : Config::List.new
+            dirty = self[k].merge!(v) || dirty
+            next
           end
 
           ## Overwrite non-Hash values


### PR DESCRIPTION
when multiple layers set the same value. This change fixes several critical flaws in the Attributes class and Config module, which never really should have worked, TBH.
- Attributes' child nodes are now correctly defined and cached for both collections and namespaces. Parent references are now set for all entities.
- `dirty` state detection was critically flawed: It was using invalid logical operators in several places.
- Include/extend functionality in collections did not correctly merge base values with override values, resulting in unstable `dirty` state.
- The `dirty?` logic in Config would never become `false` given that iterations re-merge layers with the same `compiled` layer.

Fixes #33
