### PR TITLE
Fixes #43: Pulling from a branch other than 'master' failed

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -105,9 +105,9 @@ Fetch remote artifacts for builds
   * `git` Fetch a git repository
   * `github` Fetch a git repository from a GitHub URI (e.g. `OWNER/REPO`) using the SSH protocol. You must have a valid SSH key configuration for public GitHub.
 * Git-specific parameters:
-  * `branch`
-  * `tag`
-  * `ref`
+  * `remote` - The name of the remote repository at `git` or `github`. Defaults to `origin`
+  * `branch` - The SCM branch to check out. Defaults to `master`
+  * `tag` or `ref` - A SHA-ish or SCM tag to check out. Overrides `branch`.
   * `rel` Checkout a sub-directory of a git repository
 
 ## Namespace `cleaner`

--- a/lib/builderator/config/file.rb
+++ b/lib/builderator/config/file.rb
@@ -273,6 +273,7 @@ module Builderator
 
         attribute :git
         attribute :github
+        attribute :remote
         attribute :branch
         attribute :tag
         attribute :ref

--- a/lib/builderator/tasks/vendor.rb
+++ b/lib/builderator/tasks/vendor.rb
@@ -53,16 +53,20 @@ module Builderator
 
       no_commands do
         def _fetch_git(path, params)
-          empty_directory path
+          ## Ensure that there isn't already something there
+          unless path.join('.git').exist?
+            remove_dir path
+            empty_directory path
+          end
 
           inside path do
             ## Initialize new repository
             unless path.join('.git').exist?
               run 'git init'
-              run "git remote add origin #{ params.git }"
+              run "git remote add #{ params.fetch(:remote, 'origin') } #{ params.git }"
             end
 
-            run 'git fetch origin --tags --prune'
+            run "git fetch #{ params.fetch(:remote, 'origin') } --tags --prune"
 
             ## Checkout reference
             if params.has?(:tag) then run "git checkout #{ params.tag }"
@@ -71,7 +75,7 @@ module Builderator
               run "git checkout #{ params.fetch(:branch, 'master') }"
 
               ## Only pull if a tracking branch is checked out
-              run 'git pull'
+              run "git pull #{ params.fetch(:remote, 'origin') } #{ params.fetch(:branch, 'master') }"
             end
 
             ## Apply relative subdirectory


### PR DESCRIPTION
The remote and branch were not passed to `git pull`, which failed because
said branch did not have a remote tracking branch configured.
