### PR TITLE
Switches the aws-sdk depenceny to aws-sdk-core

### DIFF
--- a/builderator.gemspec
+++ b/builderator.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 0.35'
   spec.add_development_dependency 'thor-scmversion', '1.7.0'
 
-  spec.add_dependency 'aws-sdk', '~> 2.0'
+  spec.add_dependency 'aws-sdk-core', '~> 2.0'
   spec.add_dependency 'berkshelf', '~> 3.2'
   spec.add_dependency 'chef', '~> 12.0'
   spec.add_dependency 'faraday_middleware', '~> 0.10.0'

--- a/lib/builderator/control/data/image.rb
+++ b/lib/builderator/control/data/image.rb
@@ -1,4 +1,4 @@
-require 'aws-sdk'
+require 'aws-sdk-core'
 require 'date'
 
 require_relative '../../util'

--- a/lib/builderator/model/cleaner/images.rb
+++ b/lib/builderator/model/cleaner/images.rb
@@ -1,4 +1,4 @@
-require 'aws-sdk'
+require 'aws-sdk-core'
 require_relative '../../util'
 
 module Builderator

--- a/lib/builderator/model/cleaner/instances.rb
+++ b/lib/builderator/model/cleaner/instances.rb
@@ -1,4 +1,4 @@
-require 'aws-sdk'
+require 'aws-sdk-core'
 require_relative '../../util'
 
 module Builderator

--- a/lib/builderator/model/cleaner/launch_configs.rb
+++ b/lib/builderator/model/cleaner/launch_configs.rb
@@ -1,4 +1,4 @@
-require 'aws-sdk'
+require 'aws-sdk-core'
 require_relative '../../util'
 
 module Builderator

--- a/lib/builderator/model/cleaner/scaling_groups.rb
+++ b/lib/builderator/model/cleaner/scaling_groups.rb
@@ -1,4 +1,4 @@
-require 'aws-sdk'
+require 'aws-sdk-core'
 require_relative '../../util'
 
 module Builderator

--- a/lib/builderator/model/cleaner/snapshots.rb
+++ b/lib/builderator/model/cleaner/snapshots.rb
@@ -1,4 +1,4 @@
-require 'aws-sdk'
+require 'aws-sdk-core'
 require_relative '../../util'
 
 module Builderator

--- a/lib/builderator/model/cleaner/volumes.rb
+++ b/lib/builderator/model/cleaner/volumes.rb
@@ -1,4 +1,4 @@
-require 'aws-sdk'
+require 'aws-sdk-core'
 require_relative '../../util'
 
 module Builderator


### PR DESCRIPTION
This should prevent conflicts with apps that are using the 1.0 sdk.
