### PR TITLE
Fix hash attribute keys

### DIFF
--- a/lib/builderator/config/attributes.rb
+++ b/lib/builderator/config/attributes.rb
@@ -42,7 +42,7 @@ module Builderator
               ## Instantiate List if it doesn't exist yet. `||=` will always return a new Rash.
               @attributes[attribute_name] = Config::Rash.new unless @attributes.has?(attribute_name, Config::Rash)
 
-              dirty(@attributes[attribute_name].merge!(arg).any?) unless arg.nil?
+              dirty(@attributes[attribute_name].merge!(Config::Rash.coerce(arg)).any?) unless arg.nil?
               @attributes[attribute_name]
             end
 

--- a/lib/builderator/config/rash.rb
+++ b/lib/builderator/config/rash.rb
@@ -56,9 +56,9 @@ module Builderator
         fail TypeError, 'Argument other of  `Rash#merge!(other)` must be a Hash.'\
                         " Recieved #{other.class}" unless other.is_a?(Hash)
 
-        other.each_with_object([]) do |(k, v), diff|
+        other.each_with_object({}) do |(k, v), diff|
           ## Replace `-`s with `_`s in in String keys
-          k = k.gsub(/\-/, '_') if k.is_a?(String)
+          k = k.gsub(/\-/, '_').to_sym if k.is_a?(String)
 
           next if has?(k) && self[k] == v
 
@@ -67,21 +67,21 @@ module Builderator
             self[k] = has?(k) ? Config::List.coerce(self[k]) : Config::List.new
             self[k].merge!(v)
 
-            diff << k
+            diff[k] = true
             next
           end
 
           ## Overwrite non-Hash values
           unless v.is_a?(Hash)
             self[k] = v
-            diff << k
 
+            diff[k] = true
             next
           end
 
           ## Merge recursivly coerces `v` to a Rash
           self[k] = self.class.coerce(self[k])
-          diff << self[k].merge!(v)
+          diff[k] = self[k].merge!(v)
         end
       end
 


### PR DESCRIPTION
This change ensures that hash-inputs are sanitized before they are merged during compile. Previously, String-type keys would cause compiling to fail due to equality checks with Symbol-type keys.
