### PR TITLE
Add an argument to the `config` task to allow one top-level key to be…

### DIFF
--- a/lib/builderator/tasks.rb
+++ b/lib/builderator/tasks.rb
@@ -86,8 +86,10 @@ module Builderator
       # Helper/utility commands
       ##
       desc 'config', 'Print compiled configuration'
-      def config
+      def config(key = nil)
         invoke Tasks::Version, :current, [], options
+
+        return puts Config.compiled.send(key).to_json unless key.nil?
         puts Config.compiled.to_json
       end
 


### PR DESCRIPTION
… printed instead of the whole hash
