### PR TITLE
📝 Fix a markdown syntax error in README.md (fixes #53)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Provision an EC2 VM using Vagrant. Same workflow as `local` using the `vagrant-a
 
 ### `image [PROFILE = default]`
 
-Use [Packer](packer.io) to build an image(s) for the specified profile.
+Use [Packer](https://www.packer.io) to build an image(s) for the specified profile.
 
 ## Configuration
 


### PR DESCRIPTION
Fix #53:

`[Packer](packer.io)` refers to the file `./packer.io` which is
non-existant. The https scheme must be specified to link to the packer
website.
