### PR TITLE
Allow arbitrary tags in a scm repo

### DIFF
--- a/lib/builderator/control/version.rb
+++ b/lib/builderator/control/version.rb
@@ -58,7 +58,7 @@ module Builderator
         ## Parse a SemVer string into a Version
         def from_string(arg, options = {})
           matchdata = arg.match(FORMAT)
-          fail "Builderator::Control::Version.from_string: #{arg} is not a supported semver string" if matchdata.nil?
+          return nil if matchdata.nil?
 
           new(matchdata[:major], matchdata[:minor], matchdata[:patch], matchdata[:build], options).tap do |version|
             version.is_prerelease = !matchdata[:prerelease].nil?

--- a/lib/builderator/control/version/scm.rb
+++ b/lib/builderator/control/version/scm.rb
@@ -14,6 +14,7 @@ module Builderator
         def tags
           @tags ||= _tags
                     .map { |tag, ref| Version.from_string(tag, :ref => ref) }
+                    .compact
                     .sort
         end
 

--- a/spec/data/history.json
+++ b/spec/data/history.json
@@ -1,7 +1,10 @@
 [
   {
     "id": "d6f0ae080a484b40687350110f15795bdcde6d7e",
-    "message": "In reset, check for the setter-method instead of the getter-method"
+    "message": "In reset, check for the setter-method instead of the getter-method",
+    "tags": [
+      "help"
+    ]
   },
   {
     "id": "506d7d8d17c49d80c7d4e72cd7ebbe67c04d679d",
@@ -17,7 +20,10 @@
   },
   {
     "id": "a1d3dcbd91a0abff829f8f09337ddc257257e730",
-    "message": "Merge pull request #14 from rapid7/gemspec"
+    "message": "Merge pull request #14 from rapid7/gemspec",
+    "tags": [
+      "not.the.tag.you.are.looking.for"
+    ]
   },
   {
     "id": "c3a0b2402ddf4084c175cc69793d592f8864daf1",
@@ -37,7 +43,10 @@
   },
   {
     "id": "560cea5ea897a2c9e6a484aa5ed95e1a0d81b9c9",
-    "message": "Add berkshelf_config parameter to berkshelf interface, and copy tags from profile to packer-builders in the packer interface"
+    "message": "Add berkshelf_config parameter to berkshelf interface, and copy tags from profile to packer-builders in the packer interface",
+    "tags": [
+      "not_the_tag_you_are_looking_for"
+    ]
   },
   {
     "id": "89403f24e8a4a82ffa67eb941d5afefe55ced37a",

--- a/spec/version_spec.rb
+++ b/spec/version_spec.rb
@@ -93,14 +93,14 @@ module Builderator
               expect(version.build).to be == 9
             end
 
-            it 'fails on invalid specs' do
-              expect { Version.from_string('1.2.lizard-alpha.42+build.9') }.to raise_error RuntimeError
-              expect { Version.from_string('1.2.3-alpha.42+taco.9') }.to raise_error RuntimeError
-              expect { Version.from_string('1.2.3-alpha.guacamole+build.9') }.to raise_error RuntimeError
-              expect { Version.from_string('1.2.3-alpha.42+build.beef') }.to raise_error RuntimeError
-              expect { Version.from_string('1.2.dog') }.to raise_error RuntimeError
-              expect { Version.from_string('1.cat.3') }.to raise_error RuntimeError
-              expect { Version.from_string('cow.2.3') }.to raise_error RuntimeError
+            it 'does not fail on invalid specs' do
+              expect(Version.from_string('1.2.lizard-alpha.42+build.9')).to be_nil
+              expect(Version.from_string('1.2.3-alpha.42+taco.9')).to be_nil
+              expect(Version.from_string('1.2.3-alpha.guacamole+build.9')).to be_nil
+              expect(Version.from_string('1.2.3-alpha.42+build.beef')).to be_nil
+              expect(Version.from_string('1.2.dog')).to be_nil
+              expect(Version.from_string('1.cat.3')).to be_nil
+              expect(Version.from_string('cow.2.3')).to be_nil
             end
           end
 


### PR DESCRIPTION
This change allows tags that don't match the version regex.  This is
useful if you want to use Builderator with a repo that you
don't control tagging.

Fixes #60
