### PR TITLE
Fixes Vagrant shell task

### DIFF
--- a/template/Vagrantfile.erb
+++ b/template/Vagrantfile.erb
@@ -41,8 +41,8 @@ Vagrant.configure('2') do |config|
   # Use the standard data directory for Chef
   ##
   config.vm.provision :shell,
-                      :inline => "sudo mkdir -p #{Config.chef.staging_directory}/cache && "\
-                                 "sudo chown $(whoami) -R #{Config.chef.staging_directory}",
+                      :inline => "sudo mkdir -p <%= chef.staging_directory %>/cache && "\
+                                 "sudo chown $(whoami) -R <%= chef.staging_directory %>",
                       :privileged => true
 
   ##


### PR DESCRIPTION
This ensures Builderator will template the necessary values.
