### PR TITLE
Fix berkshelf upload

### DIFF
--- a/lib/builderator/tasks/berkshelf.rb
+++ b/lib/builderator/tasks/berkshelf.rb
@@ -43,7 +43,9 @@ module Builderator
         command << "-c #{Interface.berkshelf.berkshelf_config} "
         command << "-b #{Interface.berkshelf.source}"
 
-        run command
+        inside Interface.berkshelf.directory do
+          run command
+        end
       end
 
       desc 'uncache', 'Delete the Berkshelf cache'


### PR DESCRIPTION
This commit fixes the path from which we are running `berks upload`.
