### PR TITLE
Update Vagrantfile.erb

### DIFF
--- a/template/Vagrantfile.erb
+++ b/template/Vagrantfile.erb
@@ -43,7 +43,7 @@ Vagrant.configure('2') do |config|
   config.vm.provision :shell,
                       :inline => "sudo mkdir -p <%= chef.staging_directory %>/cache && "\
                                  "sudo chown $(whoami) -R <%= chef.staging_directory %>",
-                      :privileged => true
+                      :privileged => false
 
   ##
   # Sync build artifacts to the VM


### PR DESCRIPTION
If executed as the privileged user, `sudo chown $(whoami)` will evaluate to `sudo chown root` and incorrectly set permissions on the chef folder, preventing the build artifact from being SCPed to the VM. The default value for `privileged` is true so we have to set it explicitly to `false`.
