### PR TITLE
Update the embedded berkshelf version to ~> 4.3

### DIFF
--- a/builderator.gemspec
+++ b/builderator.gemspec
@@ -24,8 +24,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'thor-scmversion', '1.7.0'
 
   spec.add_dependency 'aws-sdk', '~> 2.0'
-  spec.add_dependency 'berkshelf', '~> 3.2'
-  spec.add_dependency 'chef', '~> 12.0'
+  spec.add_dependency 'berkshelf', '~> 4.3'
+  spec.add_dependency 'dep_selector', '~> 1.0'
+  # spec.add_dependency 'chef', '~> 12.5'
   spec.add_dependency 'faraday_middleware', '~> 0.10.0'
   spec.add_dependency 'ignorefile'
   spec.add_dependency 'thor', '~> 0.19.0'

--- a/lib/builderator/patch/berkshelf.rb
+++ b/lib/builderator/patch/berkshelf.rb
@@ -1,10 +1,10 @@
+# Monkey patch to handle the case where Content-Type headers returned by servers
+# say "gzip" by the resulting message body isn't in gzip format.
+# TODO Remove this when we upgrade Berkshelf and the gzip response goes away.
+# https://github.com/berkshelf/berkshelf-api-client/blob/v1.3.0/lib/berkshelf/api_client/connection.rb#L37
 require 'faraday_middleware'
 
 module FaradayMiddleware
-  # Monkey patch to handle the case where Content-Type headers returned by servers
-  # say "gzip" by the resulting message body isn't in gzip format.
-  # TODO Remove this when we upgrade Berkshelf and the gzip response goes away.
-  # https://github.com/berkshelf/berkshelf-api-client/blob/v1.3.0/lib/berkshelf/api_client/connection.rb#L37
   class Gzip
     alias_method :__uncompress_gzip__, :uncompress_gzip
     def uncompress_gzip(body)
@@ -16,3 +16,8 @@ module FaradayMiddleware
 end
 
 Faraday::Response.register_middleware :gzip => FaradayMiddleware::Gzip
+
+# Force Berkshelf to use the gecode dependency solver
+require 'solve'
+
+Solve.engine = :gecode

--- a/template/Vagrantfile.erb
+++ b/template/Vagrantfile.erb
@@ -2,6 +2,8 @@
 # vi: set ft=ruby :
 
 Vagrant.configure('2') do |config|
+  config.berkshelf.enabled = false if Vagrant.has_plugin? 'vagrant-berkshelf'
+
   config.vm.hostname = 'builderator-<%= build_name %>'
 
   ## Local Provider


### PR DESCRIPTION
Berkshelf 4 upgraded the solve library to major version 2. This changed default behavior in such a way that broke resolution of circular cookbook dependencies. We need to explicitly install dep_selector and specify the gecode solver engine.
