### PR TITLE
Remove defaults for berkshelf config.json path

### DIFF
--- a/lib/builderator/config/defaults.rb
+++ b/lib/builderator/config/defaults.rb
@@ -29,7 +29,6 @@ module Builderator
 
       cookbook do |cookbook|
         cookbook.path = '.'
-        cookbook.berkshelf_config = ::File.join(ENV['HOME'], '.berkshelf/config.json')
         cookbook.add_source 'https://supermarket.chef.io'
       end
 

--- a/lib/builderator/tasks/berkshelf.rb
+++ b/lib/builderator/tasks/berkshelf.rb
@@ -41,7 +41,7 @@ module Builderator
         empty_directory Interface.berkshelf.vendor
 
         command = "#{Interface.berkshelf.command} vendor #{Interface.berkshelf.vendor} "
-        command << "-c #{Interface.berkshelf.berkshelf_config} "
+        command << "-c #{Interface.berkshelf.berkshelf_config} " unless Interface.berkshelf.berkshelf_config.nil?
         command << "-b #{Interface.berkshelf.source}"
 
         inside Interface.berkshelf.directory do
@@ -55,7 +55,7 @@ module Builderator
         vendor
 
         command = "#{Interface.berkshelf.command} upload "
-        command << "-c #{Interface.berkshelf.berkshelf_config} "
+        command << "-c #{Interface.berkshelf.berkshelf_config} " unless Interface.berkshelf.berkshelf_config.nil?
         command << "-b #{Interface.berkshelf.source}"
 
         inside Interface.berkshelf.directory do


### PR DESCRIPTION
This allows us to set the configuration path with an ENV variable, or to specify a path
explicitly in a buildfile if desired.
