### PR TITLE
Add the pending state to the cleaner-image filter

### DIFF
--- a/lib/builderator/model/cleaner/images.rb
+++ b/lib/builderator/model/cleaner/images.rb
@@ -22,7 +22,7 @@ module Builderator
             Util.ec2.describe_images(:filters => [
               {
                 :name => 'state',
-                :values => %w(available)
+                :values => %w(available pending)
               }
             ], :owners => %w(self)).each do |page|
               page.images.each do |image|


### PR DESCRIPTION
This adds pending images to the set used to exclude snapshots for cleanup.
