### PR TITLE
Add a new run-task that strips bundler's enviroment variables

### DIFF
--- a/builderator.gemspec
+++ b/builderator.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'aws-sdk', '~> 2.0'
   spec.add_dependency 'berkshelf', '~> 4.3'
+  spec.add_dependency 'childprocess', '~> 0.5'
   spec.add_dependency 'dep_selector', '~> 1.0'
   spec.add_dependency 'chef', '~> 12.5'
   spec.add_dependency 'faraday_middleware', '~> 0.10.0'

--- a/lib/builderator/config/file.rb
+++ b/lib/builderator/config/file.rb
@@ -256,6 +256,7 @@ module Builderator
             attribute :availability_zone
             attribute :subnet_id
             attribute :private_ip_address
+            attribute :tags, :type => :hash
 
             attribute :instance_type
             attribute :security_groups, :type => :list

--- a/lib/builderator/tasks/vagrant.rb
+++ b/lib/builderator/tasks/vagrant.rb
@@ -32,7 +32,7 @@ module Builderator
           command << " up --provider=#{Config.profile.current.vagrant.local.provider} "
           command << args.join(' ')
 
-          run command
+          run_without_bundler command
         end
       end
 
@@ -45,7 +45,7 @@ module Builderator
           command << " up --provider=#{Config.profile.current.vagrant.ec2.provider} "
           command << args.join(' ')
 
-          run command
+          run_without_bundler command
         end
       end
 
@@ -57,7 +57,7 @@ module Builderator
           command = Interface.vagrant.command
           command << " provision #{args.join(' ')}"
 
-          run command
+          run_without_bundler command
         end
       end
 
@@ -69,7 +69,7 @@ module Builderator
           command = Interface.vagrant.command
           command << " status #{args.join(' ')}"
 
-          run command
+          run_without_bundler command
         end
       end
 
@@ -82,7 +82,7 @@ module Builderator
           command << " ssh #{args.join(' ')}"
 
           ## Connect to subprocesses STDIO
-          exec(command)
+          run_without_bundler command
         end
       end
 
@@ -96,7 +96,7 @@ module Builderator
           command << " destroy #{args.join(' ')}"
           command << ' -f' if options['force']
 
-          run command
+          run_without_bundler command
         end
       end
 
@@ -122,7 +122,7 @@ module Builderator
           command << " plugin install #{ pname }"
           command << " --plugin-version #{ plugin.version }" if plugin.has?(:version)
 
-          run command
+          run_without_bundler command
         end
       end
     end

--- a/lib/builderator/tasks/vagrant.rb
+++ b/lib/builderator/tasks/vagrant.rb
@@ -32,6 +32,7 @@ module Builderator
           command << " up --provider=#{Config.profile.current.vagrant.local.provider} "
           command << args.join(' ')
 
+          return run command if Interface.vagrant.bundled?
           run_without_bundler command
         end
       end
@@ -45,6 +46,7 @@ module Builderator
           command << " up --provider=#{Config.profile.current.vagrant.ec2.provider} "
           command << args.join(' ')
 
+          return run command if Interface.vagrant.bundled?
           run_without_bundler command
         end
       end
@@ -57,6 +59,7 @@ module Builderator
           command = Interface.vagrant.command
           command << " provision #{args.join(' ')}"
 
+          return run command if Interface.vagrant.bundled?
           run_without_bundler command
         end
       end
@@ -69,6 +72,7 @@ module Builderator
           command = Interface.vagrant.command
           command << " status #{args.join(' ')}"
 
+          return run command if Interface.vagrant.bundled?
           run_without_bundler command
         end
       end
@@ -81,7 +85,7 @@ module Builderator
           command = Interface.vagrant.command
           command << " ssh #{args.join(' ')}"
 
-          ## Connect to subprocesses STDIO
+          return run command if Interface.vagrant.bundled?
           run_without_bundler command
         end
       end
@@ -96,6 +100,7 @@ module Builderator
           command << " destroy #{args.join(' ')}"
           command << ' -f' if options['force']
 
+          return run command if Interface.vagrant.bundled?
           run_without_bundler command
         end
       end
@@ -122,6 +127,7 @@ module Builderator
           command << " plugin install #{ pname }"
           command << " --plugin-version #{ plugin.version }" if plugin.has?(:version)
 
+          return run command if Interface.vagrant.bundled?
           run_without_bundler command
         end
       end

--- a/lib/builderator/tasks/vagrant.rb
+++ b/lib/builderator/tasks/vagrant.rb
@@ -34,7 +34,7 @@ module Builderator
           command << " up --provider=#{Config.profile.current.vagrant.local.provider} "
           command << args.join(' ')
 
-          return run command if Interface.vagrant.bundled?
+          return run(command) if Interface.vagrant.bundled?
           run_without_bundler command
         end
       end
@@ -48,7 +48,7 @@ module Builderator
           command << " up --provider=#{Config.profile.current.vagrant.ec2.provider} "
           command << args.join(' ')
 
-          return run command if Interface.vagrant.bundled?
+          return run(command) if Interface.vagrant.bundled?
           run_without_bundler command
         end
       end
@@ -64,7 +64,7 @@ module Builderator
           command = Interface.vagrant.command
           command << " provision #{args.join(' ')}"
 
-          return run command if Interface.vagrant.bundled?
+          return run(command) if Interface.vagrant.bundled?
           run_without_bundler command
         end
       end
@@ -77,7 +77,7 @@ module Builderator
           command = Interface.vagrant.command
           command << " status #{args.join(' ')}"
 
-          return run command if Interface.vagrant.bundled?
+          return run(command) if Interface.vagrant.bundled?
           run_without_bundler command
         end
       end
@@ -90,7 +90,7 @@ module Builderator
           command = Interface.vagrant.command
           command << " ssh #{args.join(' ')}"
 
-          return run command if Interface.vagrant.bundled?
+          return run(command) if Interface.vagrant.bundled?
           run_without_bundler command, :childprocess => true
         end
       end
@@ -103,7 +103,7 @@ module Builderator
           command = Interface.vagrant.command
           command << " rsync #{args.join(' ')}"
 
-          return run command if Interface.vagrant.bundled?
+          return run(command) if Interface.vagrant.bundled?
           run_without_bundler command
         end
       end
@@ -118,7 +118,7 @@ module Builderator
           command << " destroy #{args.join(' ')}"
           command << ' -f' if options['force']
 
-          return run command if Interface.vagrant.bundled?
+          return run(command) if Interface.vagrant.bundled?
           run_without_bundler command
         end
       end
@@ -145,7 +145,7 @@ module Builderator
           command << " plugin install #{ pname }"
           command << " --plugin-version #{ plugin.version }" if plugin.has?(:version)
 
-          return run command if Interface.vagrant.bundled?
+          return run(command) if Interface.vagrant.bundled?
           run_without_bundler command
         end
       end

--- a/lib/builderator/tasks/vagrant.rb
+++ b/lib/builderator/tasks/vagrant.rb
@@ -91,7 +91,7 @@ module Builderator
           command << " ssh #{args.join(' ')}"
 
           return run command if Interface.vagrant.bundled?
-          run_without_bundler command
+          run_without_bundler command, :childprocess => true
         end
       end
 

--- a/template/Vagrantfile.erb
+++ b/template/Vagrantfile.erb
@@ -35,6 +35,7 @@ Vagrant.configure('2') do |config|
     ec2.iam_instance_profile_arn = '<%= profile.current.vagrant.ec2.iam_instance_profile_arn %>'
 
     ec2.ami = '<%= profile.current.vagrant.ec2.source_ami %>'
+    ec2.tags = <%= profile.current.vagrant.ec2.tags %>
   end
 
   # config.vm.network :forwarded_port, :host => 9200, :guest => 9200


### PR DESCRIPTION
This ensures that tools like Vagrant, which rely upon an internal gemset, are not FUBAR'd by the bundler context that the calling instance of builderator is running in.
