### PR TITLE
Feature: Enable Berkshelf debugging

### DIFF
--- a/lib/builderator/tasks/berkshelf.rb
+++ b/lib/builderator/tasks/berkshelf.rb
@@ -53,10 +53,12 @@ module Builderator
       end
 
       desc 'upload', 'Upload the local cookbook source and its dependencies to the Chef server'
+      option :debug, :type => :boolean, :desc => 'Show debug output'
       def upload
         vendor
 
         command = "#{Interface.berkshelf.command} upload "
+        command << "-d " if options[:debug]
         command << "-c #{Interface.berkshelf.berkshelf_config} " unless Interface.berkshelf.berkshelf_config.nil?
         command << "-b #{Interface.berkshelf.source}"
 

--- a/lib/builderator/tasks/berkshelf.rb
+++ b/lib/builderator/tasks/berkshelf.rb
@@ -36,11 +36,13 @@ module Builderator
       end
 
       desc 'vendor', 'Vendor a cookbook release and its dependencies'
+      option :debug, :type => :boolean, :desc => 'Show debug output'
       def vendor
         invoke :configure, [], options
         empty_directory Interface.berkshelf.vendor
 
         command = "#{Interface.berkshelf.command} vendor #{Interface.berkshelf.vendor} "
+        command << "-d " if options[:debug]
         command << "-c #{Interface.berkshelf.berkshelf_config} " unless Interface.berkshelf.berkshelf_config.nil?
         command << "-b #{Interface.berkshelf.source}"
 

--- a/lib/builderator/tasks/berkshelf.rb
+++ b/lib/builderator/tasks/berkshelf.rb
@@ -12,6 +12,8 @@ module Builderator
     class Berkshelf < Thor
       include Thor::Actions
 
+      class_option :debug, :type => :boolean, :desc => 'Show debug output'
+
       def self.exit_on_failure?
         true
       end
@@ -36,7 +38,6 @@ module Builderator
       end
 
       desc 'vendor', 'Vendor a cookbook release and its dependencies'
-      option :debug, :type => :boolean, :desc => 'Show debug output'
       def vendor
         invoke :configure, [], options
         empty_directory Interface.berkshelf.vendor
@@ -53,7 +54,6 @@ module Builderator
       end
 
       desc 'upload', 'Upload the local cookbook source and its dependencies to the Chef server'
-      option :debug, :type => :boolean, :desc => 'Show debug output'
       def upload
         vendor
 


### PR DESCRIPTION
This adds a `--debug` option to the `berks vendor` and `berks upload` commands. It's mostly useful when trying to track down dependency conflicts in cookbooks.
