### PR TITLE
PD-7487 Tag copied amis in remote accounts

### DIFF
--- a/lib/builderator/tasks.rb
+++ b/lib/builderator/tasks.rb
@@ -74,8 +74,8 @@ module Builderator
         prepare
 
         invoke Tasks::Packer, :build, [profile], options
-        invoke Tasks::Packer, :remote_tag, [profile], options if options['remote_tag']
         invoke Tasks::Packer, :copy, [profile], options if options['copy']
+        invoke Tasks::Packer, :remote_tag, [profile], options if options['remote_tag']
       end
 
       # desc 'cookbook SUBCOMMAND', 'Cookbook tasks'

--- a/lib/builderator/tasks/packer.rb
+++ b/lib/builderator/tasks/packer.rb
@@ -137,31 +137,38 @@ module Builderator
         allowed_cred_keys = %w(access_key_id secret_access_key session_token)
 
         images.each do |image_name, (image, build)|
-          filters = [{
-            :name => 'name',
-            :values => [image_name]
-          }]
+          ami_regions = build.ami_regions
+          ami_regions << Config.aws.region
+          ami_regions.uniq!
+          ami_regions.each do |region|
+            filters = [{
+              :name => 'name',
+              :values => [image_name]
+            }]
 
-          if build.tagging_role.nil?
-            say_status :complete, 'No remote tagging to be performed as no IAM role is defined'
-            return
-          end
-
-          build.ami_users.each do |account|
-            role_arn = "arn:aws:iam::#{account}:role/#{build.tagging_role}"
-            begin
-              response = sts_client.assume_role( :role_arn => role_arn, :role_session_name => "tag-new-ami")
-              raise "Could not assume role [#{role_arn}].  Perhaps it does not exist?" unless response.successful?
-            rescue => e
-              say_status :skip, "Got error when trying to assume role: #{e.message} - continuing."
-              next
+            if build.tagging_role.nil?
+              say_status :complete, 'No remote tagging to be performed as no IAM role is defined'
+              return
             end
 
-            creds_hash = response.credentials.to_h.keep_if { |k,v| allowed_cred_keys.include?(k.to_s) }
+            regional_image = Util.ec2(region).describe_images(:filters => filters).images.first
 
-            say_status :remote_tag, "Tag AMI #{image_name} (#{image.image_id}) in account #{account}"
-            Util.ec2(Config.aws.region, creds_hash)
-                .create_tags(:dry_run => false, :resources => [image.image_id], :tags => image.tags)
+            build.ami_users.each do |account|
+              role_arn = "arn:aws:iam::#{account}:role/#{build.tagging_role}"
+              begin
+                response = sts_client.assume_role( :role_arn => role_arn, :role_session_name => "tag-new-ami")
+                raise "Could not assume role [#{role_arn}].  Perhaps it does not exist?" unless response.successful?
+              rescue => e
+                say_status :skip, "Got error when trying to assume role: #{e.message} - continuing."
+                next
+              end
+
+              creds_hash = response.credentials.to_h.keep_if { |k,v| allowed_cred_keys.include?(k.to_s) }
+
+              say_status :remote_tag, "Tag AMI #{image_name} (#{regional_image.image_id}) in #{region} (#{account})"
+              Util.ec2(region, creds_hash)
+                  .create_tags(:dry_run => false, :resources => [regional_image.image_id], :tags => image.tags)
+            end
           end
         end
         say_status :complete, 'Remote tagging complete'

--- a/lib/builderator/tasks/packer.rb
+++ b/lib/builderator/tasks/packer.rb
@@ -133,7 +133,6 @@ module Builderator
       def remote_tag(profile)
         invoke :configure, [profile], options
 
-        sts_client = Aws::STS::Client.new(region: Config.aws.region)
         allowed_cred_keys = %w(access_key_id secret_access_key session_token)
 
         images.each do |image_name, (image, build)|
@@ -141,6 +140,9 @@ module Builderator
           ami_regions << Config.aws.region
           ami_regions.uniq!
           ami_regions.each do |region|
+
+            sts_client = Aws::STS::Client.new(region: region)
+
             filters = [{
               :name => 'name',
               :values => [image_name]


### PR DESCRIPTION
This change will tag amis that have been copied between regions in all
remote accounts.
