### PR TITLE
Prevents unwanted files from being bundled

### DIFF
--- a/builderator.gemspec
+++ b/builderator.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/rapid7/builderator'
   spec.license       = 'MIT'
 
-  spec.files         = Dir['**/*']
+  spec.files         = Dir.glob("{bin,lib,template}/**/*") + %w(LICENSE.txt README.md)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']


### PR DESCRIPTION
This change limits the files and directories we include in the gem.

It fixes the situation where you locally build the gem and try to
include in your local bundle(`gem 'builderator', path:
'../builderator'`)

This is the specific error we are trying to prevent:
Gem::InvalidSpecificationException: The gemspec at
/Users/athompson/code/builderator/builderator.gemspec is not valid.
Please fix this gemspec.
The validation error was 'builderator-0.0.1 contains itself
(builderator-0.0.1.gem), check your files list'
