### PR TITLE
Fixes support for Ruby 2.1

### DIFF
--- a/builderator.gemspec
+++ b/builderator.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'berkshelf', '~> 4.3'
   spec.add_dependency 'childprocess', '~> 0.5'
   spec.add_dependency 'dep_selector', '~> 1.0'
-  spec.add_dependency 'chef', '~> 12.5'
+  spec.add_dependency 'chef', '~> 12.13.37'
   spec.add_dependency 'faraday_middleware', '~> 0.10.0'
   spec.add_dependency 'ignorefile'
   spec.add_dependency 'thor', '~> 0.19.0'


### PR DESCRIPTION
Chef 12.14 [removed](https://github.com/chef/chef/commit/df7648421014da98dcd90d7f67eeb1008d59f806)  support for Ruby 2.1; this commit locks Builderator
to the Chef 12.13.x code line.
