### PR TITLE
Fix builderator to work with newer packer versions

### DIFF
--- a/lib/builderator/patch/thor-actions.rb
+++ b/lib/builderator/patch/thor-actions.rb
@@ -30,6 +30,7 @@ class Thor
 
       IO.popen(command, 'r+') do |io|
         io.write(input)
+        io.close_write
 
         ## Stream output
         loop do


### PR DESCRIPTION
The latest set of packer versions (0.10.2 for sure, not tested with
others) require that stdin be closed before processing a packer config
file from stdin.  Older versions didn't seem to care.

We should close stdin when done sending data no matter what packer
expects so this should be compatible with all packer versions.
