### PR TITLE
Added encrypt_boot support for root volume

### DIFF
--- a/lib/builderator/config/file.rb
+++ b/lib/builderator/config/file.rb
@@ -210,6 +210,7 @@ module Builderator
             attribute :enhanced_networking
             attribute :security_group_ids, :type => :list, :singular => :security_group_id
             attribute :iam_instance_profile
+            attribute :encrypt_boot
 
             attribute :source_ami
             attribute :user_data

--- a/lib/builderator/interface/packer.rb
+++ b/lib/builderator/interface/packer.rb
@@ -29,7 +29,11 @@ module Builderator
             end
 
             # If we specify encrypted boot, packer won't allow ami_users.
-            # See: https://github.com/mitchellh/packer/pull/4023
+            # See: https://github.com/MYOB-Technology/packer/blob/509cd7dcf194beb6ca6d0c39057f7490fa630d78/builder/amazon/common/ami_config.go#L59-L61
+
+            # A PR (https://github.com/mitchellh/packer/pull/4023) has been
+            # submitted to resolve this issue but we shouldn't remove this
+            # until a new Packer release with this feature.
             if build_hash.key?(:encrypt_boot)
               build_hash.delete(:ami_users)
             end

--- a/lib/builderator/interface/packer.rb
+++ b/lib/builderator/interface/packer.rb
@@ -28,6 +28,12 @@ module Builderator
               b[:tags] = Config.profile.current.tags
             end
 
+            # If we specify encrypted boot, packer won't allow ami_users.
+            # We have to figure out another way to share.
+            if build_hash.key?(:encrypt_boot)
+              build_hash.delete(:ami_users)
+            end
+
             ## Support is missing for several regions in some versions of Packer
             # Moving this functionality into a task until we can confirm that Packer
             # has full support again.

--- a/lib/builderator/interface/packer.rb
+++ b/lib/builderator/interface/packer.rb
@@ -29,7 +29,7 @@ module Builderator
             end
 
             # If we specify encrypted boot, packer won't allow ami_users.
-            # We have to figure out another way to share.
+            # See: https://github.com/mitchellh/packer/pull/4023
             if build_hash.key?(:encrypt_boot)
               build_hash.delete(:ami_users)
             end


### PR DESCRIPTION
This PR adds support for Packer's [encrypt_boot](https://www.packer.io/docs/builders/amazon-ebs.html#encrypt_boot) option.

Currently Packer does not support the use of `ami_users` when `encrypt_boot` is specified. There is a PR open (https://github.com/mitchellh/packer/pull/4023) with Packer to add support for named KMS CMKs (rather than the default `aws/ebs` master key) which will allow using a KMS key that is shared with other accounts. This, in turn, will allow sharing the AMI and its encrypted EBS snapshot. Once this is complete, we can refactor the [`share`](https://github.com/rapid7/builderator/blob/master/lib/builderator/tasks/packer.rb#L179) task accordingly.

This PR can be cleanly merged but does not provide full functionality in Rapid7's use case.
