### PR TITLE
Implemented binary_env attribute

### DIFF
--- a/docs/configuration/profile.md
+++ b/docs/configuration/profile.md
@@ -17,6 +17,10 @@ An externally managed resource to push to VMs and image builds, e.g. `bundle.tar
 * `run_list, type: list, singular: run_list_item, unique: true` The Chef runlist for this profile
 * `environment` The Chef environment to load for this
 * `node_attrs, type: hash` A hash of node attributes for this profile
+* `binary_env` A space separated, KEY=VALUE formatted string to pass data
+    into the provisioning process as environment variables. See
+    [the vagrant docs](https://www.vagrantup.com/docs/provisioning/chef_common.html#binary_env)
+    for more information.
 
 
 ## Namespace `packer`

--- a/lib/builderator/config/file.rb
+++ b/lib/builderator/config/file.rb
@@ -188,6 +188,7 @@ module Builderator
           attribute :run_list, :type => :list, :singular => :run_list_item
           attribute :environment
           attribute :node_attrs, :type => :hash
+          attribute :binary_env
         end
 
         ##

--- a/template/Vagrantfile.erb
+++ b/template/Vagrantfile.erb
@@ -81,6 +81,10 @@ Vagrant.configure('2') do |config|
     chef.environment = '<%= profile.current.chef.environment %>'
 <% end -%>
 
+<% unless profile.current.chef.binary_env.nil? -%>
+    chef.binary_env = '<%= profile.current.chef.binary_env %>'
+<% end -%>
+
 <% if profile.current.chef.node_attrs.nil? -%>
     chef.json = {}
 <% else -%>


### PR DESCRIPTION
This PR adds the `binary_env` attribute so we can pass data to the provisioning process as environment variables.

See [the vagrant docs](https://www.vagrantup.com/docs/provisioning/chef_common.html#binary_env) for more info.