### PR TITLE
Implement post processors

### DIFF
--- a/docs/configuration/profile.md
+++ b/docs/configuration/profile.md
@@ -109,37 +109,41 @@ Options for the `amazon-ebs` builder:
   }
   </pre>
 
-### Collection `post_processor`
+### Attribute `post_processors`
 
-Add a packer post-processor to run after the provisioning steps.
-The `post_processor` collection currently only supports the `docker-tag`,
-`docker-import`, `docker-save`, and `docker-push` post-processors.
+Add a packer post-processor to run after the provisioning steps. This is a free-form
+attribute as there is no validation of elements defined here. If invalid configuration
+is supplied, errors will only appear when Packer tries to execute them.
 
-* `type` The type of post-processor
+The `post_processors` attribute supports simple, complex, and sequence definitions.
 
-[Docker-tag][] and [docker-import][] post-processors
+Example:
 
-* `repository` The repository of the imported image
-* `tag` The tag for the imported image
-* `force` If true, the `docker-tag` post-processor forcibly tags the image even if there is a tag name collision. Defaults to `false`.
+```ruby
+packer.post_processors [
+  [
+    # Complex
+    {
+      :type => 'docker-tag',
+      :repository => 'rapid7/builderator',
+      :tag => '1.2.2'
+    },
 
-[Docker-save][] post-processor
+    'docker-push' # Simple
+  ],
 
-* `path` The path to save the image
+  # Sequence
+  [
+    {
+      :type => 'docker-tag',
+      :repository => 'rapid7/builderator',
+      :tag => 'latest'
+    },
+    'docker-push'
+  ]
+]
+```
 
-[Docker-push][] post-processor
-
-* `aws_access_key`
-* `aws_secret_key`
-* `aws_token`
-* `ecr_login`
-* `login`
-* `login_email`
-* `login_username`
-* `login_password`
-* `login_server`
-
-See the [documentation][docker-push] for configuration information.
 
 ## TODO: Share accounts
 

--- a/docs/configuration/profile.md
+++ b/docs/configuration/profile.md
@@ -22,6 +22,12 @@ An externally managed resource to push to VMs and image builds, e.g. `bundle.tar
     [the vagrant docs](https://www.vagrantup.com/docs/provisioning/chef_common.html#binary_env)
     for more information.
 
+## Collection `provisioner`
+
+Packer/Vagrant provisioner definitions. Currently only supports inline shell provisioners.
+
+* `inline, type: list` A list of shell provisioners
+* `environment_vars, type: list` A list of environment vars (in `KEY=VALUE` format) to pass to the shell script
 
 ## Namespace `packer`
 

--- a/lib/builderator/config/attributes.rb
+++ b/lib/builderator/config/attributes.rb
@@ -25,7 +25,7 @@ module Builderator
 
               unless arg.empty?
                 @attributes[attribute_name].set(*arg.flatten)
-                @attributes[attribute_name].set(*arg) if options[:dimension] == :broad
+                @attributes[attribute_name].set(*arg) if options[:flatten] == false
               end
               @attributes[attribute_name]
             end

--- a/lib/builderator/config/attributes.rb
+++ b/lib/builderator/config/attributes.rb
@@ -23,7 +23,10 @@ module Builderator
               ## Instantiate List if it doesn't exist yet. `||=` will always return a new Rash.
               @attributes[attribute_name] = Config::List.new(run_options) unless @attributes.has?(attribute_name, Config::List)
 
-              @attributes[attribute_name].set(*arg.flatten) unless arg.empty?
+              unless arg.empty?
+                @attributes[attribute_name].set(*arg.flatten)
+                @attributes[attribute_name].set(*arg) if options[:dimension] == :broad
+              end
               @attributes[attribute_name]
             end
 

--- a/lib/builderator/config/file.rb
+++ b/lib/builderator/config/file.rb
@@ -266,7 +266,7 @@ module Builderator
             attribute :tagging_role
           end
 
-          attribute :post_processors, :type => :list, :dimension => :broad
+          attribute :post_processors, :type => :list, :flatten => false
         end
 
         ##

--- a/lib/builderator/config/file.rb
+++ b/lib/builderator/config/file.rb
@@ -191,6 +191,11 @@ module Builderator
           attribute :binary_env
         end
 
+        collection :provisioner do
+          attribute :inline, :type => :list
+          attribute :environment_vars, :type => :list
+        end
+
         ##
         # Packerfile
         #

--- a/lib/builderator/config/file.rb
+++ b/lib/builderator/config/file.rb
@@ -261,28 +261,7 @@ module Builderator
             attribute :tagging_role
           end
 
-          collection :post_processor do
-            attribute :type
-
-            ## Docker-tag and docker-import post-processors
-            attribute :repository
-            attribute :tag
-            attribute :force
-
-            ## Docker-save post-processor
-            attribute :path
-
-            ## Docker-push post-processor
-            attribute :aws_access_key
-            attribute :aws_secret_key
-            attribute :aws_token
-            attribute :ecr_login
-            attribute :login
-            attribute :login_email
-            attribute :login_username
-            attribute :login_password
-            attribute :login_server
-          end
+          attribute :post_processors, :type => :list, :dimension => :broad
         end
 
         ##

--- a/lib/builderator/interface/packer.rb
+++ b/lib/builderator/interface/packer.rb
@@ -63,24 +63,10 @@ module Builderator
             json[:builders] << build_hash
           end
 
-          post_processors = []
-
-          # Post-processors should be considered as a sequence
-          Config.profile.current.packer.post_processor.each do |name, post_processor|
-            post_processor_hash = post_processor.to_hash
-
-            # Single, named step in a sequence
-            if post_processor_hash.empty?
-              post_processors << name
-              next
-            end
-
-            # The post-processor's type should be the same as the name
-            post_processor_hash[:type] = name
-
-            post_processors << post_processor_hash
-          end
-          json['post-processors'].push(post_processors)
+          # post_processors must be a List of Rashes.
+          post_processors = Config.profile.current.packer.post_processors.to_a
+          json['post-processors'] = post_processors.first unless post_processors.empty?
+          json.delete('post-processors') if json['post-processors'].compact.empty?
 
           ## Initialize the staging directory unless using the docker builder
           json[:provisioners] << {
@@ -89,17 +75,28 @@ module Builderator
                        "sudo chown $(whoami) -R #{Config.chef.staging_directory}"
           } if docker_builders.empty?
 
-          json.delete('post-processors') if json['post-processors'].empty?
-        end
+          # Only add artifact provisioners if they're defined
+          Config.profile.current.artifact.each do |_, artifact|
+            json[:provisioners] << _artifact_provisioner(artifact)
+          end unless Config.profile.current.artifact.attributes.empty?
 
-        _artifact_provisioners
+          # Only add chef provisioners if they're defined
+          unless Config.profile.current.chef.attributes.empty?
+            # There are certain options (staging directory, run as sudo) that don't apply
+            # to the docker builder.
+            json[:provisioners] << if docker_builders.empty?
+                                     _chef_provisioner
+                                   else
+                                     _chef_provisioner_docker
+                                   end
+          end
 
-        # There are certain options (staging directory, run as sudo) that don't apply
-        # to the docker builder.
-        if docker_builders.empty?
-          _chef_provisioner
-        else
-          _chef_provisioner_docker
+          # After adding the default provisioners, we add any additional ones to the provisioners array
+          Config.profile.current.provisioner.each do |name, provisioner|
+            json[:provisioners] << provisioner.attributes.tap { |p| p[:type] = name.to_s }
+          end
+
+          json.delete(:provisioners) if json[:provisioners].empty?
         end
       end
 
@@ -110,25 +107,23 @@ module Builderator
       private
 
       ## Upload artifacts to the build container
-      def _artifact_provisioners
-        Config.profile.current.artifact.each do |_, artifact|
-          packerfile[:provisioners] << {
+      def _artifact_provisioner(artifact)
+        {
             :type => 'file',
             :source => artifact.path,
             :destination => artifact.destination
-          }
-        end
+        }
       end
 
       def _chef_provisioner
-        packerfile[:provisioners] << _chef_provisioner_base.merge(
+        _chef_provisioner_base.merge(
           :staging_directory => Config.chef.staging_directory,
           :install_command => _chef_install_command
         )
       end
 
       def _chef_provisioner_docker
-        packerfile[:provisioners] << _chef_provisioner_base.merge(
+        _chef_provisioner_base.merge(
           :prevent_sudo => true,
           :install_command => _chef_install_command(false)
         )

--- a/spec/interface_spec.rb
+++ b/spec/interface_spec.rb
@@ -37,7 +37,6 @@ module Builderator
     end
 
     context 'Packer post-processors' do
-      require 'pp'
       before(:example) do
         Config.reset!
         Config.load(::File.expand_path('../resource/Buildfile-with-post-processors', __FILE__))

--- a/spec/resource/Buildfile-with-post-processors
+++ b/spec/resource/Buildfile-with-post-processors
@@ -1,0 +1,82 @@
+##
+# This test file simulates a Buildfile with a set of post-processors
+##
+build_name 'builderator-with-post-processors'
+
+profile :single do |single|
+  single.packer do |packer|
+    packer.build :docker do |build|
+      build.commit true
+      build.image 'openjdk:8-jdk'
+    end
+
+    packer.post_processors [
+      'docker-push'
+    ]
+  end
+end
+
+profile :complex do |complex|
+  complex.packer do |packer|
+    packer.build :docker do |build|
+      build.commit true
+      build.image 'openjdk:8-jdk'
+    end
+
+    packer.post_processors [
+      {
+        :type => 'docker-tag',
+        :repository => 'rapid7/builderator',
+        :tag => 'latest'
+      }
+    ]
+  end
+end
+
+profile :sequence do |sequence|
+  sequence.packer do |packer|
+    packer.build :docker do |build|
+      build.commit true
+      build.image 'openjdk:8-jdk'
+    end
+
+    packer.post_processors [
+      [
+        {
+          :type => 'docker-tag',
+          :repository => 'rapid7/builderator',
+          :tag => 'latest'
+        },
+        'docker-push'
+      ]
+    ]
+  end
+end
+
+profile :multiple_sequences do |sequence|
+  sequence.packer do |packer|
+    packer.build :docker do |build|
+      build.commit true
+      build.image 'openjdk:8-jdk'
+    end
+
+    packer.post_processors [
+      [
+        {
+          :type => 'docker-tag',
+          :repository => 'rapid7/builderator',
+          :tag => '1.2.2'
+        },
+        'docker-push'
+      ],
+      [
+        {
+          :type => 'docker-tag',
+          :repository => 'rapid7/builderator',
+          :tag => 'latest'
+        },
+        'docker-push'
+      ]
+    ]
+  end
+end

--- a/template/Vagrantfile.erb
+++ b/template/Vagrantfile.erb
@@ -94,4 +94,16 @@ Vagrant.configure('2') do |config|
     ## Tell Chef that this is a Vagrant build
     chef.json[:vagrant] = true
   end
+
+<%- profile.current.provisioner.each do |name, provisioner| -%>
+    <%- provisioner.each do |func, val| -%>
+        <%- if val.is_a?(Array) -%>
+          <%- val.each do |v| -%>
+  config.vm.provision "<%= name %>", <%= func %>: "<%= v %>"
+          <%- end -%>
+        <%- else -%>
+  config.vm.provision "<%= name %>", <%= func %>: "<%= val %>"
+      <%- end -%>
+    <%- end -%>
+  <%- end -%>
 end


### PR DESCRIPTION
This PR generally implements Packer [post-processors](https://www.packer.io/docs/templates/post-processors.html) as a `:list` attribute rather than a collection. The impact of this change is that now, for example, a 2 sequences of post processors is defined as such:

```ruby
packer.post_processors [
  [
    {
      :type => 'docker-tag',
      :repository => 'rapid7/builderator',
      :tag => '1.2.2'
    },
    'docker-push'
  ],
  [
    {
      :type => 'docker-tag',
      :repository => 'rapid7/builderator',
      :tag => 'latest'
    },
    'docker-push'
  ]
]
```

Secondarily, this PR adds support for inline shell provisioners.