### PR TITLE
Implemented ECR repository lookup helper.

### DIFF
--- a/lib/builderator/control/data.rb
+++ b/lib/builderator/control/data.rb
@@ -14,3 +14,4 @@ module Builderator
 end
 
 require_relative './data/image'
+require_relative './data/ecr'

--- a/lib/builderator/control/data/ecr.rb
+++ b/lib/builderator/control/data/ecr.rb
@@ -1,0 +1,40 @@
+require 'aws-sdk'
+require 'date'
+
+require_relative '../../util'
+
+module Builderator
+  module Control
+    # :nodoc:
+    module Data
+      # Lookup ECR repository info
+      #
+      # NB. We want to embed the login_server info into the returned repo data for
+      # ease of use. Thus, instead of an AWS struct-type, we get a hash with the
+      # injected value.
+      def self.repository(query = {})
+        ECR.search(query).map do |repo|
+          repo.to_h.tap { |r| r[:login_server] = "https://#{repo.repository_uri.sub(repo.repository_name, '')}" }
+          end
+        end
+      end
+
+      ##
+      # Find ECR repositories for sources
+      ##
+      module ECR
+        class << self
+          def search(query = {})
+            options = {}
+
+            options['repository_names'] = Util.to_array(query.delete('name')) if query.include?('name')
+            options['registry_id'] = query.delete('owner') if query.include?('owner')
+
+            Util.ecr.describe_repositories(options)
+              .each_with_object([]) { |page, repositories| repositories.push(*page.repositories) }
+              .sort { |a, b| a.repository_name <=> b.repository_name }
+          end
+        end
+      end
+    end
+end

--- a/lib/builderator/util.rb
+++ b/lib/builderator/util.rb
@@ -71,6 +71,10 @@ module Builderator
         end
       end
 
+      def ecr(region = Config.aws.region)
+        clients["ecr-#{region}"] ||= Aws::ECR::Client.new(:region => region)
+      end
+
       def asg(region = Config.aws.region)
         clients["asg-#{region}"] ||= Aws::AutoScaling::Client.new(:region => region)
       end


### PR DESCRIPTION
This PR adds `lookup()` functionality for ECR repositories. An example of use is:

```ruby
# Buildfile
profile :docker => Config.profile(:docker) do |docker|
  docker.packer do |packer|
    packer.build :docker do |build|
      build.commit true
      build.image 'openjdk:8-jdk'
    end
    
    # lookup(:repository, query) returns a Hash
    # {
    #    :repository_uri
    #    :login_server
    #    :repository_name
    #    :repository_arn
    #    :registry_id
    #    :created_at
    # }
    repo = lookup(:repository, 'name' => 'test', 'owner' => '012345678901')
    repo_uri = repo && repo.first && repo.first[:repository_uri]
    repo_login_server = repo && repo.first && repo.first[:login_server]

    packer.post_processors [
      [
        {
          :type => 'docker-tag',
          :repository => repo_uri,
          :tag => '1.2.2'
        },
        {
          :type => 'docker-push',
          :ecr_login => true,
          :login_server => repo_login_server
        }
      ],
      [
        {
          :type => 'docker-tag',
          :repository => repo_uri,
          :tag => 'latest'
        },
        {
          :type => 'docker-push',
          :ecr_login => true,
          :login_server => repo_login_server
        }
      ]
    ]
  end
end
```
