### PR TITLE
Tag packer build instance and volume

### DIFF
--- a/docs/configuration/profile.md
+++ b/docs/configuration/profile.md
@@ -67,6 +67,14 @@ Options for the `amazon-ebs` builder:
        bake.packer do |packer|
          packer.build :default do |build|
            build.tagging_role 'CreateTagsOnAllImages'
+           build.run_tags {
+             'Owner' => 'ops',
+             'Product' => 'packer'
+           }
+           build.run_volume_tags {
+             'Owner' => 'ops',
+             'Product' => 'packer'
+           }
          end
        end
      end

--- a/lib/builderator/config/file.rb
+++ b/lib/builderator/config/file.rb
@@ -262,6 +262,10 @@ module Builderator
             attribute :ami_users, :type => :list
             attribute :ami_regions, :type => :list
 
+            # Tagging
+            attribute :run_tags, :type => :hash
+            attribute :run_volume_tags, :type => :hash
+
             ## Assumable role for tagging AMIs in remote accounts
             attribute :tagging_role
           end


### PR DESCRIPTION
This adds support to add tags to the instances and volumes that the amazon-ebs builder creates.