### PR TITLE
Fix #112 - Support vendoring URL resources

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -193,6 +193,7 @@ Fetch remote artifacts for builds
 
 * Sources:
   * `path` Link to a local file/directory
+  * `url` Link to a remote file/directory to download via HTTP
   * `git` Fetch a git repository
   * `github` Fetch a git repository from a GitHub URI (e.g. `OWNER/REPO`) using the SSH protocol. You must have a valid SSH key configuration for public GitHub.
 * Git-specific parameters:

--- a/lib/builderator/config/file.rb
+++ b/lib/builderator/config/file.rb
@@ -332,6 +332,8 @@ module Builderator
       collection :vendor do
         attribute :path, :relative => true
 
+        attribute :url
+
         attribute :git
         attribute :github
         attribute :remote

--- a/lib/builderator/tasks/vendor.rb
+++ b/lib/builderator/tasks/vendor.rb
@@ -42,6 +42,9 @@ module Builderator
         elsif params.has?(:git)
           say_status :vendor, "#{ name } from git repository #{ params.git }"
           _fetch_git(path, params)
+        elsif params.has?(:url)
+          say_status :vendor, "#{ name } from remote url #{ params.url }"
+          _fetch_url(path, params)
         elsif params.has?(:path)
           say_status :vendor, "#{ name } from path #{ params.path }"
           _fetch_path(path, params)
@@ -96,6 +99,11 @@ module Builderator
         def _fetch_path(path, params)
           remove_dir path.to_s if path.exist?
           create_link path.to_s, params.path.to_s
+        end
+
+        def _fetch_url(path, params)
+          remove_file path.to_s if path.exist?
+          get params.url, path.to_s
         end
       end
     end


### PR DESCRIPTION
Fix #112 — Add a new `url` source to the `vendor` collection.

cc @anowak-r7 @vchaudhari-r7 Internally you guys may be able to use this to pull resources into your AMI using a buildfile like we do for regular services. I'll ping you more specifically in our private chat (vs. this open source issue).