### PR TITLE
Stop execution when a command fails

### DIFF
--- a/lib/builderator/patch/thor-actions.rb
+++ b/lib/builderator/patch/thor-actions.rb
@@ -82,6 +82,12 @@ class Thor
       end
     end
 
+    alias_method :thor_run, :run
+    def run(command, config = {})
+      thor_run(command, config)
+      fail "Command failed: #{command}" if $?.exitstatus != 0
+    end
+
     ##
     # Make `template` load from a sane path and render in the context of Config
     ##


### PR DESCRIPTION
This changes the behavior of `Thor::Actions.run` to `fail` when the
command exits with a non 0 exit code.