### PR TITLE
Use microsecond timestamp when creating security group

### DIFF
--- a/lib/builderator/util.rb
+++ b/lib/builderator/util.rb
@@ -106,8 +106,8 @@ module Builderator
         external_ip = open('http://checkip.amazonaws.com').read.strip
         cidr_ip = external_ip + '/32'
 
-        # Create a security group
-        resp = ec2.create_security_group(group_name: "BuilderatorSecurityGroupSSHOnly-#{Time.now.to_i}",
+        # Create a security group with microsecond timestamp (to avoid collisions when using seconds)
+        resp = ec2.create_security_group(group_name: "BuilderatorSecurityGroupSSHOnly-#{(Time.now.to_f*1000000).to_i}",
                                          description: "Created by Builderator at #{Time.now}")
         group_id = resp[:group_id]
 

--- a/lib/builderator/util.rb
+++ b/lib/builderator/util.rb
@@ -107,7 +107,8 @@ module Builderator
         cidr_ip = external_ip + '/32'
 
         # Create a security group with microsecond timestamp (to avoid collisions when using seconds)
-        resp = ec2.create_security_group(group_name: "BuilderatorSecurityGroupSSHOnly-#{(Time.now.to_f*1000000).to_i}",
+        ts_usec = (Time.now.to_f*1000000).to_i
+        resp = ec2.create_security_group(group_name: "BuilderatorSecurityGroupSSHOnly-#{ts_usec}",
                                          description: "Created by Builderator at #{Time.now}")
         group_id = resp[:group_id]
 


### PR DESCRIPTION
PhaaS specifically has a job which builds like 10 jobs at once, and it
just so happened that two different jobs tried to create a security
group with the exact same timestamp.  This was surprising enough, but I
would be much more surprised if this race condition still occurs after
this commit.