### PR TITLE
Feature: Allow block device mappings

### DIFF
--- a/lib/builderator/config/defaults.rb
+++ b/lib/builderator/config/defaults.rb
@@ -79,6 +79,16 @@ module Builderator
             # Ints will be interpreted as ns.  Buyer beware.
             build.ssh_timeout '300s'
 
+            # Clear the default AMI block device mappings for c3.large instance
+            # types.
+            build.ami_block_device_mappings [{
+              'device_name' => '/dev/sdb',
+              'no_device' => true,
+            }, {
+              'device_name' => '/dev/sdc',
+              'no_device' => true,
+            }]
+
             build.ami_name [Config.build_name, Config.version, Config.build_number].reject(&:nil?).join('-')
             build.ami_description Config.description
           end

--- a/lib/builderator/config/defaults.rb
+++ b/lib/builderator/config/defaults.rb
@@ -79,9 +79,16 @@ module Builderator
             # Ints will be interpreted as ns.  Buyer beware.
             build.ssh_timeout '300s'
 
-            # Clear the default AMI block device mappings for c3.large instance
-            # types.
+            # Clear the AMI and launch block device mappings for the default
+            # c3.large instance type.
             build.ami_block_device_mappings [{
+              'device_name' => '/dev/sdb',
+              'no_device' => true,
+            }, {
+              'device_name' => '/dev/sdc',
+              'no_device' => true,
+            }]
+            build.launch_block_device_mappings [{
               'device_name' => '/dev/sdb',
               'no_device' => true,
             }, {

--- a/lib/builderator/config/file.rb
+++ b/lib/builderator/config/file.rb
@@ -214,6 +214,7 @@ module Builderator
             attribute :export_path
 
             # Optional attributes
+            attribute :ami_block_device_mappings, :type => :list
             attribute :author
             attribute :aws_access_key
             attribute :aws_secret_key

--- a/lib/builderator/config/file.rb
+++ b/lib/builderator/config/file.rb
@@ -221,6 +221,7 @@ module Builderator
             attribute :aws_token
             attribute :changes, :type => :list
             attribute :ecr_login
+            attribute :launch_block_device_mappings, :type => :list
             attribute :login
             attribute :login_email
             attribute :login_username

--- a/spec/interface_spec.rb
+++ b/spec/interface_spec.rb
@@ -114,6 +114,16 @@ module Builderator
           'no_device' => true,
         }]
       end
+
+      it 'generates a Packer launch block device mapping' do
+        Config.profile.use('launch_mappings')
+        packer = Interface::Packer.new
+        mappings = packer.packerfile[:builders].first[:launch_block_device_mappings]
+        expect(mappings).to eq [{
+          'device_name' => '/dev/sda',
+          'no_device' => true,
+        }]
+      end
     end
   end
 end

--- a/spec/interface_spec.rb
+++ b/spec/interface_spec.rb
@@ -97,5 +97,23 @@ module Builderator
         ]
       end
     end
+
+    context 'Packer block-device-mappings' do
+      before(:example) do
+        Config.reset!
+        Config.load(::File.expand_path('../resource/Buildfile-with-block-device-mappings', __FILE__))
+        Config.compile
+      end
+
+      it 'generates an AMI block device mapping' do
+        Config.profile.use('ami_mappings')
+        packer = Interface::Packer.new
+        mappings = packer.packerfile[:builders].first[:ami_block_device_mappings]
+        expect(mappings).to eq [{
+          'device_name' => '/dev/sda',
+          'no_device' => true,
+        }]
+      end
+    end
   end
 end

--- a/spec/resource/Buildfile-with-block-device-mappings
+++ b/spec/resource/Buildfile-with-block-device-mappings
@@ -13,3 +13,14 @@ profile :ami_mappings do |ami|
     end
   end
 end
+
+profile :launch_mappings do |ami|
+  ami.packer do |packer|
+    packer.build :aws do |build|
+      build.launch_block_device_mappings [{
+        'device_name' => '/dev/sda',
+        'no_device' => true,
+      }]
+    end
+  end
+end

--- a/spec/resource/Buildfile-with-block-device-mappings
+++ b/spec/resource/Buildfile-with-block-device-mappings
@@ -1,0 +1,15 @@
+##
+# This test file simulates a Buildfile with block device mappings
+##
+build_name 'builderator-with-block-device-mappings'
+
+profile :ami_mappings do |ami|
+  ami.packer do |packer|
+    packer.build :aws do |build|
+      build.ami_block_device_mappings [{
+        'device_name' => '/dev/sda',
+        'no_device' => true,
+      }]
+    end
+  end
+end


### PR DESCRIPTION
This allows Builderator to send [block device mapping settings](https://www.packer.io/docs/builders/amazon-ebs.html#ami_block_device_mappings) to Packer. The default `c3.large` instance type has two block device mappings: `/dev/sdb` and `/dev/sdc`. We clear them for the instance Packer launches and the AMI Packer creates.