### PR TITLE
Use correct/new chef url for installing chef

### DIFF
--- a/lib/builderator/interface/packer.rb
+++ b/lib/builderator/interface/packer.rb
@@ -171,7 +171,7 @@ module Builderator
 
       def _chef_install_command(sudo = true)
         template = sudo ? 'sudo ' : ''
-        "curl -L https://www.chef.io/chef/install.sh | #{template}bash -s -- -v #{Config.chef.version}"
+        "curl -L https://omnitruck.chef.io/install.sh | #{template}bash -s -- -v #{Config.chef.version}"
       end
     end
   end


### PR DESCRIPTION
Based on https://docs.chef.io/install_omnibus.html the correct url to install
chef from is https://omnitruck.chef.io/install.sh  and not
https://www.chef.io/chef/install.sh