### PR TITLE
PD-26575 try increasing image grab retries 

### DIFF
--- a/lib/builderator/tasks/packer.rb
+++ b/lib/builderator/tasks/packer.rb
@@ -199,7 +199,7 @@ module Builderator
 
       ## Find details for generated images in current region
       def images
-        Retryable.retryable(:sleep => lambda { |n| 4**n }, :tries => 4, :on => [NoMethodError]) do |retries, _|
+        Retryable.retryable(:sleep => lambda { |n| 4**n }, :tries => 10, :on => [NoMethodError]) do |retries, _|
           @images ||= Config.profile.current.packer.build.each_with_object({}) do |(_, build), memo|
             memo[build.ami_name] = [Control::Data.lookup(:image, :name => build.ami_name).first, build]
           end


### PR DESCRIPTION
This PR increases the retry attempts on getting a new AMI from AWS to see if the following error is caused by a timing issue:

https://razorci.osdc.lax.rapid7.com/job/image-rapid7-consul-server-ubuntu1804/13/console