### PR TITLE
PD-26575 add additional sleep call before fuser to prevent dpkg lock error

### DIFF
--- a/lib/builderator/interface/packer.rb
+++ b/lib/builderator/interface/packer.rb
@@ -172,7 +172,7 @@ module Builderator
       def _chef_install_command(sudo = true)
         template = sudo ? 'sudo ' : ''
         bash_cmd = "#{template}bash"
-        "#{bash_cmd} -a -c 'while #{template}fuser /var/lib/dpkg/lock >/dev/null 2>&1; do sleep 5; done; curl -L https://www.chef.io/chef/install.sh' | #{bash_cmd} -s -- -v #{Config.chef.version}"
+        "sleep 10; #{bash_cmd} -a -c 'while #{template}fuser /var/lib/dpkg/lock >/dev/null 2>&1; do sleep 5; done; curl -L https://www.chef.io/chef/install.sh' | #{bash_cmd} -s -- -v #{Config.chef.version}"
       end
     end
   end


### PR DESCRIPTION
This PR adds a sleep call to wait before installing chef to prevent the following:

https://razorci.osdc.lax.rapid7.com/job/image-rapid7-consul-server-ubuntu1804/13/console